### PR TITLE
Manage Members/Add Members down arrow fix

### DIFF
--- a/frontend/client/Styles/screens/manage_teams.scss
+++ b/frontend/client/Styles/screens/manage_teams.scss
@@ -45,7 +45,7 @@ table {
         background-color: #ffffff;
         border-radius: 0;
         select {
-          padding: 0 10px;
+          padding: 5px 10px;
           border: none;
           width: 100%;
           height: 100%;
@@ -70,9 +70,10 @@ table {
         content: url('../../assets/arrow-down.svg');
         position: absolute;
         right: 10px;
-        top: 7px;
+        top: 10px;
         border-radius: 0;
         background-color: transparent;
+        pointer-events: none;
       }
       .settings-container {
         display: flex;


### PR DESCRIPTION
Resolves   #376 
  
Improved padding on select elements to make them fill their container better, made down arrows clickable.  
  
Image preview of the change:  
![image](https://user-images.githubusercontent.com/56734437/88233766-1f1d1c80-cc46-11ea-9f85-f5a33feec4c8.png)