### PR TITLE
SendGrid email adjustments

### DIFF
--- a/cloud-functions/functions/src/index.ts
+++ b/cloud-functions/functions/src/index.ts
@@ -187,7 +187,7 @@ function sendNewUserEmail(email: string, password: string, firstName: string, la
     <p ${EMAILSTYLE}>Please click the following link or copy and paste it into your browser to sign in to your new account:</p>
     <p ${EMAILSTYLE}><a href=${link}>Sign In</a></p>
     <p ${EMAILSTYLE}>If you received this message in error, you can safely ignore it.</p>
-    <p ${EMAILSTYLE}>You can reply to this message, or email support@covidwatch.org if you have any questions.</p>
+    <p ${EMAILSTYLE}>If you have questions, please email support@covidwatch.org.</p>
     <p ${EMAILSTYLE}>Thank you,<br />Covid Watch Team</p> `,
       };
       sgMail

--- a/cloud-functions/functions/src/index.ts
+++ b/cloud-functions/functions/src/index.ts
@@ -177,8 +177,8 @@ function sendNewUserEmail(email: string, password: string, firstName: string, la
     .then((link) => {
       const msg = {
         to: email,
-        from: 'welcome@covid-watch.org',
-        subject: 'Welcome to the Covid Watch Permission Portal',
+        from: 'noreply@covidwatch.org',
+        subject: 'Welcome to the Covid Watch Portal',
         html: `
     <!DOCTYPE html>
     <p ${EMAILSTYLE}>${firstName} ${lastName},</p>
@@ -186,8 +186,8 @@ function sendNewUserEmail(email: string, password: string, firstName: string, la
     <p ${EMAILSTYLE}><b>Your user name:</b> ${email}<br />  <b>Your temporary password:</b> ${password}</p>
     <p ${EMAILSTYLE}>Please click the following link or copy and paste it into your browser to sign in to your new account:</p>
     <p ${EMAILSTYLE}><a href=${link}>Sign In</a></p>
-    <p ${EMAILSTYLE}>If you recieved this message in error, you can safely ignore it.</p>
-    <p ${EMAILSTYLE}>You can reply to this message, or email support@covid-watch.org if you have any questions.</p>
+    <p ${EMAILSTYLE}>If you received this message in error, you can safely ignore it.</p>
+    <p ${EMAILSTYLE}>You can reply to this message, or email support@covidwatch.org if you have any questions.</p>
     <p ${EMAILSTYLE}>Thank you,<br />Covid Watch Team</p> `,
       };
       sgMail
@@ -210,7 +210,7 @@ function sendPasswordRecoveryEmail(email: string) {
     .then((link) => {
       const msg = {
         to: email,
-        from: 'recovery@covid-watch.org',
+        from: 'noreply@covidwatch.org',
         subject: 'Password Recovery Requested',
         html: `
         <!DOCTYPE html>
@@ -245,8 +245,8 @@ function sendPasswordResetEmail(email: string) {
     .then((pwdResetLink) => {
       const msg = {
         to: email,
-        from: 'password-reset@covid-watch.org',
-        subject: 'Covid Watch Permission Portal password reset',
+        from: 'noreply@covidwatch.org',
+        subject: 'Covid Watch Portal password reset',
         html: `
         <p>You are recieving this email because somebody requested a password reset for the account associated with this email address.</p>
         <p>To reset your password, click the link below</p>


### PR DESCRIPTION
Closes #371 

1) set all sending email addresses to noreply@covidwatch.org
2) fix the 'recieve' typo to 'receive'
3) remove any mention of "Covid Watch Permission Portal" to just "Covid Watch Portal"