### PR TITLE
Resolve magic link syntax error

### DIFF
--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -81,13 +81,12 @@ const SignInFormBase = observer(
             // Common errors could be invalid email and invalid or expired OTPs.
             Logging.error(err)
             if (err.code === 'auth/expired-action-code') {
-              this.state.toastMessage =
-                'This magic link has expired. Please sign in with your password or restart the password recovery process.'
+              this.setState({ toastMessage: 'This magic link has expired. Please sign in with your password or restart the password recovery process.' })
             } else {
               // Neither auth/invalid-email nor auth/user-disabled should happen
-              this.state.toastMessage = 'Invalid magic link'
+              this.setState({ toastMessage: 'Invalid magic link' })
             }
-            this.errorToast.show()
+            this.errorToast.current.show()
           })
       }
     }


### PR DESCRIPTION
I saw this error happening in staging reported in Sentry logs, which was worrisome so I investigated and found a small syntax error in `Login.js` using `this.errorToast.show()` instead of `this.errorToast.current.show()`.  I also adjusted how state is set so it isn't set directly which is bad form and can lead to bugs (more on why it's bad form [here](https://daveceddia.com/why-not-modify-react-state-directly/) if curious).


<img width="683" alt="Screen Shot 2020-07-23 at 9 09 16 AM" src="https://user-images.githubusercontent.com/16062590/88310766-0e1fea00-ccde-11ea-9008-026106b2a33e.png">
