### PR TITLE
Remove unused package file-system

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5956,23 +5956,6 @@
         }
       }
     },
-    "file-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
-      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
-      "requires": {
-        "utils-extend": "^1.0.6"
-      }
-    },
-    "file-system": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
-      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
-      "requires": {
-        "file-match": "^1.0.1",
-        "utils-extend": "^1.0.4"
-      }
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -13166,11 +13149,6 @@
         "has-symbols": "^1.0.1",
         "object.getownpropertydescriptors": "^2.1.0"
       }
-    },
-    "utils-extend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
-      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "cors": "^2.8.5",
     "cpy-cli": "^3.1.1",
     "express": "^4.17.1",
-    "file-system": "^2.2.2",
     "firebase": "^7.14.5",
     "mobx": "^5.15.4",
     "mobx-react": "^6.2.2",


### PR DESCRIPTION
`file-system` contains [a vulnerability](https://www.npmjs.com/advisories/1502) that hasn't been addressed in over 4 months. Since we're not using it anyway, this vulnerability doesn't affect us, but at least it won't bother `npm audit`.