### PR TITLE
remove hyphens from code in code generation page

### DIFF
--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -181,7 +181,7 @@ const CodeValidationsBase = observer((props) => {
             Generate Code
           </PendingOperationButton>
           <div id="code-box" className="no-value">
-            {code.slice(0, 3)}-{code.slice(3, 6)}-{code.slice(6)}
+            {code}
           </div>
 
           {needsReset && (


### PR DESCRIPTION
A request from Zsombor

## Result (no code generated in the screenshot):
<img width="540" alt="Screen Shot 2020-07-23 at 11 58 41 AM" src="https://user-images.githubusercontent.com/16062590/88327598-36671300-ccf5-11ea-9020-9fb8fc439964.png">
