### PR TITLE
add sentry environment to label and filter error reports better

### DIFF
--- a/frontend/client/index.js
+++ b/frontend/client/index.js
@@ -4,6 +4,9 @@ import App from './App'
 import * as Sentry from '@sentry/react'
 import './styles/index.scss'
 
-Sentry.init({ dsn: 'https://13821d959c3a4f10944bb8ef579d034d@o410040.ingest.sentry.io/5283616' })
+Sentry.init({ 
+    dsn: 'https://13821d959c3a4f10944bb8ef579d034d@o410040.ingest.sentry.io/5283616',
+    environment: window.env
+})
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/frontend/client/src/store/firebase.js
+++ b/frontend/client/src/store/firebase.js
@@ -22,6 +22,10 @@ const config = firebaseConfigMap[process.env ? process.env.NODE_ENV : 'developme
 
 Logging.log(`process.env.NODE_ENV = ${process.env.NODE_ENV}`)
 
+// declaring this as a global variable for use in index.js for Sentry environment labeling like "development", "staging", and "production"
+window.env = process.env.NODE_ENV
+
+
 app.initializeApp(config)
 const auth = app.auth()
 const SESSION = app.auth.Auth.Persistence.SESSION


### PR DESCRIPTION
I'm pretty sure that this will achieve what I have in mind.  It seems to work in local environment (see screenshot below) but I want to test in staging environment also.

If there is a better way to import the environment string to `index.js` better than declaring a global window variable, feel free to suggest.  I made sure that this variable is only a string like "staging" or similar so doesn't expose any vulnerabilities or sensitive info.

Screenshot from a local environment in Sentry interface:

<img width="1195" alt="Screen Shot 2020-07-23 at 4 38 07 PM" src="https://user-images.githubusercontent.com/16062590/88348662-0d0dad80-cd1c-11ea-90fe-a9b374b351c3.png">