### PR TITLE
Modal header consistency adjustments

### DIFF
--- a/frontend/client/src/components/AddMemberModal.js
+++ b/frontend/client/src/components/AddMemberModal.js
@@ -103,7 +103,7 @@ const AddMemberModalBase = observer((props) => {
   // TODO needs to fail but not close on validation failure and high light invalid fields (can do that before touching the store)
   return (
     <Modal hidden={props.hidden} onClose={props.onClose} containerClass="add-member-modal-container">
-      <h2>Add Member</h2>
+      <h3>Add Member</h3>
       <div className="add-member-form">
         <label htmlFor="firstName">
           First Name<span>*</span>

--- a/frontend/client/styles/screens/change_password_modal.scss
+++ b/frontend/client/styles/screens/change_password_modal.scss
@@ -13,7 +13,7 @@
     margin-top: 0px;
     margin-bottom: 17px;
     font-weight: 600;
-    font-size: 28px;
+    font-size: 22px;
   }
 
   p {


### PR DESCRIPTION
Simple change.  Closes #393 

The Recover Password modal header spacing was already resolved by another PR and is live in staging corrected currently.

See visual preview of AddMemberModal: 

<img width="431" alt="Screen Shot 2020-07-23 at 8 34 02 PM" src="https://user-images.githubusercontent.com/16062590/88358453-06436280-cd3d-11ea-91b1-2923dd76fc2f.png">

And adjustment of `<h2>` to `<h3>` for ChangePasswordModal to be consistent w other modals.  The result: 

<img width="521" alt="Screen Shot 2020-07-23 at 8 35 16 PM" src="https://user-images.githubusercontent.com/16062590/88358493-2e32c600-cd3d-11ea-97f9-9597025276cf.png">

