### PR TITLE
Loading graphic doesn't move elements when loaded

### DIFF
--- a/frontend/client/src/components/ChangeRoleModal.js
+++ b/frontend/client/src/components/ChangeRoleModal.js
@@ -27,12 +27,14 @@ const ChangeRoleModal = withStore((props) => {
         To: <b>{toRole}</b>
       </p>
 
-      <button className="button btn-medium btn-secondary" onClick={props.onClose}>
-        Cancel
-      </button>
-      <PendingOperationButton className="confirm" operation={onConfirm}>
-        Confirm
-      </PendingOperationButton>
+      <div className="buttons-container">
+        <button className="button btn-medium btn-secondary" onClick={props.onClose}>
+          Cancel
+        </button>
+        <PendingOperationButton className="confirm" operation={onConfirm}>
+          Confirm
+        </PendingOperationButton>
+      </div>
     </Modal>
   )
 })

--- a/frontend/client/src/components/ChangeStatusModal.js
+++ b/frontend/client/src/components/ChangeStatusModal.js
@@ -20,12 +20,14 @@ const ChangeStatusModal = withStore((props) => {
         Please confirm that you would like to change the status of <b>{fullName}</b> to <b>{toStatus}</b>.
       </p>
 
-      <button className="button btn-medium btn-secondary" onClick={props.onClose}>
-        Cancel
-      </button>
-      <PendingOperationButton className="confirm" operation={onConfirm}>
-        Confirm
-      </PendingOperationButton>
+      <div className="buttons-container">
+        <button className="button btn-medium btn-secondary" onClick={props.onClose}>
+          Cancel
+        </button>
+        <PendingOperationButton className="confirm" operation={onConfirm}>
+          Confirm
+        </PendingOperationButton>
+      </div>
     </Modal>
   )
 })

--- a/frontend/client/src/components/ForgotPasswordModal.js
+++ b/frontend/client/src/components/ForgotPasswordModal.js
@@ -46,7 +46,7 @@ class ForgotPasswordModal extends React.Component {
               Email or User Name
             </label>
             <input className="small-text" type="text" id="email-or-username" required />
-            <PendingOperationButton operation={this.onSubmit} className="save-button recovery-button">
+            <PendingOperationButton operation={this.onSubmit} className="save-button">
               Email Recovery Link
             </PendingOperationButton>
             {!this.state.validEmail && <div className="validationResult">Please enter a valid email or user name.</div>}

--- a/frontend/client/src/components/PendingOperationButton.js
+++ b/frontend/client/src/components/PendingOperationButton.js
@@ -30,9 +30,11 @@ const PendingOperationButton = (props) => {
 
   if (!isOperationPending) {
     return (
-      <button className={className} disabled={disabled} style={style} onClick={startOperation}>
-        {props.children}
-      </button>
+      <div className="progress-container">
+        <button className={className} disabled={disabled} style={style} onClick={startOperation}>
+          {props.children}
+        </button>
+      </div>
     )
   } else {
     return (

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -141,12 +141,12 @@ const SettingsBase = observer((props) => {
   }
 
   const changeImageModal = loading ? (
-    <div className="modal-content">
+    <div className="modal-content image-modal">
       <h3>Uploading image...</h3>
       <CircularProgress />
     </div>
   ) : (
-    <div className="modal-content">
+    <div className="modal-content image-modal">
       <h3> Please Select a File to Upload </h3>
       <input type="file" ref={imgUploader} accepts="image/jpeg, image/png" />
       <PendingOperationButton operation={saveImage} className="btn-medium">

--- a/frontend/client/styles/components/profile_photo.scss
+++ b/frontend/client/styles/components/profile_photo.scss
@@ -7,3 +7,10 @@
     cursor: pointer;
   }
 }
+
+.image-modal {
+  .progress-container {
+    margin-top: 0px;
+    display: block;
+  }
+}

--- a/frontend/client/styles/screens/add_member_modal.scss
+++ b/frontend/client/styles/screens/add_member_modal.scss
@@ -45,7 +45,6 @@
   .button {
     width: 350px;
     height: 49px !important;
-    margin-top: 30px;
   }
   select {
     margin-left: 48px;

--- a/frontend/client/styles/screens/change_password_modal.scss
+++ b/frontend/client/styles/screens/change_password_modal.scss
@@ -71,4 +71,12 @@
       border: 2px solid $lightMediumGray;
     }
   }
+
+  .progress-container {
+    margin-top: 0px;
+    display: flex;
+    justify-content: center;
+    // height is hacky for now - modal refactor should address this in better way
+    height: 70px;
+  }
 }

--- a/frontend/client/styles/screens/change_role_modal.scss
+++ b/frontend/client/styles/screens/change_role_modal.scss
@@ -24,7 +24,18 @@
   .button {
     width: 165px;
     height: 40px;
-    margin-top: 32px;
+  }
+
+  .buttons-container {
+    display: flex;
+    align-items: flex-end;
+    padding-top: 20px;
+  }
+
+  .progress-container {
+    margin-top: 0px;
+    display: flex;
+    align-items: flex-end;
   }
   
   .confirm {

--- a/frontend/client/styles/screens/change_status_modal.scss
+++ b/frontend/client/styles/screens/change_status_modal.scss
@@ -15,8 +15,19 @@
 
   .button {
     width: 165px;
-    height: 45px;
-    margin-top: 32px;
+    height: 40px;
+  }
+
+    .buttons-container {
+    display: flex;
+    align-items: flex-end;
+    padding-top: 20px;
+  }
+
+  .progress-container {
+    margin-top: 0px;
+    display: flex;
+    align-items: flex-end;
   }
   
   .confirm {

--- a/frontend/client/styles/screens/login.scss
+++ b/frontend/client/styles/screens/login.scss
@@ -47,9 +47,6 @@
     margin-bottom: 10px;
     margin-top: 25px;
   }
-  .button {
-    margin-top: 43px;
-  }
   a {
     text-align: center;
     margin-top: 30px;


### PR DESCRIPTION
Closes #364 

My goal with this was to use a consistent `progress-container` class as a wrapper for all `PendingOperationButtons` to create one consistent solution for the loading graphic to not displace other elements vertically when loaded.  However I quickly realized that this wouldn't actually work for all cases (like when there are two buttons beside each other and one is a Cancel button that is NOT a `<PendingOperationButton>` (this happens a lot in the modals).  

So I ended up doing a hodge podge of mostly CSS changes here and there to prevent the jerky effect when the loading graphic loads on the page in any context.

Please test thoroughly all buttons and `<PendingOperationButton>` cases to make sure nothing is clearly messed up.  I think I got them all (including the one that loads when a user first sets their password the first time) but good to triple check.

Consistency across modals is still an issue -- the value of doing a modal refactor for consistency is a post-v4 but important refactoring.