### PR TITLE
update the hamburger menu option names to match v4 better

### DIFF
--- a/frontend/client/src/components/NavBar.js
+++ b/frontend/client/src/components/NavBar.js
@@ -91,7 +91,7 @@ const NavBarBase = observer((props) => {
         onClose={handleClose}
       >
         <MenuItem className={classes.link} style={{ marginTop: 22 }} onClick={() => onClickMenuItem(0)}>
-          Positive Test Validations
+          Diagnosis Verification Codes
         </MenuItem>
         {props.store.data.user.isAdmin && (
           <MenuItem className={classes.link} onClick={() => onClickMenuItem(1)}>


### PR DESCRIPTION
I made the unilateral decision to keep "Account Settings" to "Mobile App Settings", bc I thought "Account Settings" would be confusing next to "My Settings".  Either way, I imagine we will change this in the future to be more clear once we have a clearer function for the "Account Settings" page.

Otherwise this matches v4 Figma for the hamburger menu options.