### PR TITLE
remove permissions urls in functions for sendgrid email

### DIFF
--- a/config/functions.config.prod.js
+++ b/config/functions.config.prod.js
@@ -1,6 +1,6 @@
 var config = {
   client: {
-    url: "https://permissions.covidwatch.org/",
+    url: "https://portal.covidwatch.org/",
   },
   sendgrid: {
     key: process.env.SENDGRID_API_KEY,

--- a/config/functions.config.staging.js
+++ b/config/functions.config.staging.js
@@ -1,6 +1,6 @@
 var config = {
   client: {
-    url: "https://staging-permissions.covidwatch.org/",
+    url: "https://staging-portal.covidwatch.org/",
   },
   sendgrid: {
     key: process.env.SENDGRID_API_KEY,


### PR DESCRIPTION
As the permissions URLs are no longer available via AWS.  I maybe should have set up forwarding but in lieu of that modifying the sendgrid URL here.