### PR TITLE
Closing Add Member Modal Now Resets State

### DIFF
--- a/frontend/client/src/components/AddMemberModal.js
+++ b/frontend/client/src/components/AddMemberModal.js
@@ -34,21 +34,23 @@ const ValidationRules = [
   },
 ]
 
+const defaultState = {
+  firstName: '',
+  firstNameValidationFailed: false,
+  firstNameValidationMessage: '',
+  lastName: '',
+  lastNameValidationFailed: false,
+  lastNameValidationMessage: '',
+  email: '',
+  emailValidationFailed: false,
+  emailValidationMessage: '',
+  role: ROLES.NON_ADMIN_LABEL,
+  roleValidationFailed: false,
+  roleValidationMessage: '',
+}
+
 const AddMemberModalBase = observer((props) => {
-  const [state, setState] = useState({
-    firstName: '',
-    firstNameValidationFailed: false,
-    firstNameValidationMessage: '',
-    lastName: '',
-    lastNameValidationFailed: false,
-    lastNameValidationMessage: '',
-    email: '',
-    emailValidationFailed: false,
-    emailValidationMessage: '',
-    role: ROLES.NON_ADMIN_LABEL,
-    roleValidationFailed: false,
-    roleValidationMessage: '',
-  })
+  const [state, setState] = useState(defaultState)
 
   const tryCreateUser = () => {
     let newState = {}
@@ -101,9 +103,14 @@ const AddMemberModalBase = observer((props) => {
     }
   }
 
+  const resetAndClose = () => {
+    props.onClose()
+    setState(defaultState)
+  }
+
   // TODO needs to fail but not close on validation failure and high light invalid fields (can do that before touching the store)
   return (
-    <Modal hidden={props.hidden} onClose={props.onClose} containerClass="add-member-modal-container">
+    <Modal hidden={props.hidden} onClose={resetAndClose} containerClass="add-member-modal-container">
       <h3>Add Member</h3>
       <div className="add-member-form">
         <label htmlFor="firstName">

--- a/frontend/client/src/components/AddMemberModal.js
+++ b/frontend/client/src/components/AddMemberModal.js
@@ -88,7 +88,10 @@ const AddMemberModalBase = observer((props) => {
         lastName: state.lastName,
         isAdmin: state.role === ROLES.ADMIN_LABEL,
       })
-      .then(props.onSuccess, props.onFailure)
+      .then(() => {
+        props.onSuccess()
+        setState(defaultState)
+      }, props.onFailure)
   }
 
   function handleChange(e) {


### PR DESCRIPTION
Resolves #417  
  
Adding a member now clears the state so their information does not appear again when opening modal. Closing a modal while in progress of adding a member now resets state as well.
  
