### PR TITLE
Reset Password Fix

### DIFF
--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -36,24 +36,24 @@ class ResetPasswordModalBase extends React.Component {
     this.setState((state) => {
       let newState = {}
 
-      switch(fieldName) {
+      switch (fieldName) {
         case 'current-password':
           newState.currentPassword = fieldContent
           newState.currentPasswordHasBeenEdited = true
-          break;
+          break
         case 'new-password':
           newState.newPasswordHasBeenEdited = true
           newState.password = fieldContent
           newState.passwordIsValid = newState.password && newState.password.length >= 6
           newState.passwordsMatch = newState.password === state.confirmPassword
-          break;
+          break
         case 'confirm-password':
           newState.confirmPasswordHasBeenEdited = true
           newState.confirmPassword = fieldContent
           newState.passwordsMatch = state.password === newState.confirmPassword
-          break;
+          break
         default:
-          return;
+          return
       }
 
       return newState
@@ -79,7 +79,8 @@ class ResetPasswordModalBase extends React.Component {
     user
       .reauthenticateWithCredential(credential)
       .then(() => {
-        if (currentPassword === password) return this.props.onFailure('New password must be different than your current password. Please try again.')
+        if (currentPassword === password)
+          return this.props.onFailure('New password must be different than your current password. Please try again.')
         user
           .updatePassword(password)
           .then(this.props.onSuccess())


### PR DESCRIPTION
Resolves #416  
  
Reset password modal now rejects your new password if it is the same as the inputted current password. Updated `onChange` function of `ResetPasswordModalBase` to use a switch statement for better readability/efficiency.  
  
Note: this does not fix issues associated with the "forgot your password" reset via the login page (you are able to use the same password as the previous).