### PR TITLE
Deploy script update for favicon

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1

--- a/frontend/scripts/deploy.sh
+++ b/frontend/scripts/deploy.sh
@@ -17,8 +17,22 @@ echo
 FOLDERNAME=dist
 S3_BUCKET_URI="s3://$BUCKETNAME"
 
-aws s3 cp index.html $S3_BUCKET_URI  --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors
+# Upload index.html and favicon if they've changed
+diff=$(git diff --name-only HEAD HEAD~1)
 
+if echo $diff | grep -q index.html; then  
+    echo Uploading index.html
+    aws s3 cp index.html $S3_BUCKET_URI  --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors
+fi
+
+
+if echo $diff | grep -q favicon.ico; then  
+    echo Uploading favicon.ico
+    aws s3 cp favicon.ico $S3_BUCKET_URI  --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors
+fi
+
+
+# Upload /dist (bundled web app)
 aws s3 sync $FOLDERNAME "$S3_BUCKET_URI/$FOLDERNAME" --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors
 
 


### PR DESCRIPTION
Closes #415 

Updates the deploy script to upload the favicon to AWS S3.

Reviewing `deploy.sh` I realized we're uploading `index.html` to S3 every push, which isn't necessary as it never changes at this point. And I think we're charged (a very small amount) for each upload. So, `deploy.sh` now only uploads `index.html` and `favicon.ico` to S3 if they were modified in the previous commit. Our usual strategy is to merge a PR into dev/master, so this really checks if `index.html` and `favicon.ico` were changed in the previous PR. Needed to update the action workflow to get the last 2 commits instead of the last 1. 

As this is a change to the deploy script/workflow, we'll want to watch closely for a PR or 2 to make sure everything still works. 