### PR TITLE
Convert time before sending to getVerificationCode

### DIFF
--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -171,7 +171,7 @@ const CodeValidationsBase = observer((props) => {
               onChange={handleDate}
             ></input>
           </form>
-          <div className="date-desc">Timezone set to {getDefaultTimezoneString()}</div>
+          <div className="date-desc">Time zone set to {getDefaultTimezoneString()}</div>
         </div>
       </div>
 

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -7,7 +7,15 @@ import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import PendingOperationButton from '../components/PendingOperationButton'
 import Clock from '../../assets/clock.svg'
-import { getOneHourAhead, getFourteenDaysAgo, moreThanFourteenDaysAgo, dateInFuture, getUTCDate } from '../util/time'
+import {
+  getOneHourAheadDisplayString,
+  getFourteenDaysAgoString,
+  moreThanFourteenDaysAgo,
+  dateInFuture,
+  getTodayString,
+  getDefaultTimezoneString,
+  localStringToZeroUTCOffsetString,
+} from '../util/time'
 
 const codePlaceholder = '00000000'
 
@@ -44,7 +52,7 @@ const CodeValidationsBase = observer((props) => {
     try {
       let code = await props.store.getVerificationCode({
         testType: testType,
-        symptomDate: symptomDate,
+        symptomDate: symptomDate === '' ? symptomDate : localStringToZeroUTCOffsetString(symptomDate),
       })
       setCode(code.data.split('').join(''))
       codeTimeStamp()
@@ -104,7 +112,7 @@ const CodeValidationsBase = observer((props) => {
     document.getElementById('code-box').classList.toggle('no-value')
     document.getElementById('code-box').classList.toggle('code-generated')
     setCodeGenStamp(new Date().getMinutes())
-    setExpirationTime(getOneHourAhead())
+    setExpirationTime(getOneHourAheadDisplayString())
   }
 
   return !props.store.data.user.isSignedIn ||
@@ -158,13 +166,12 @@ const CodeValidationsBase = observer((props) => {
               id="date-picker"
               className="no-value"
               type="date"
-              min={getFourteenDaysAgo()}
-              max={getUTCDate()}
+              min={getFourteenDaysAgoString()}
+              max={getTodayString()}
               onChange={handleDate}
             ></input>
           </form>
-          <div className="date-desc">This system is based on UTC dates, so you may need to adjust accordingly.</div>
-          <div className="date-sub-desc">The current UTC date is {new Date().toJSON().substring(0, 10)}</div>
+          <div className="date-desc">Timezone set to {getDefaultTimezoneString()}</div>
         </div>
       </div>
 

--- a/frontend/client/src/util/time.js
+++ b/frontend/client/src/util/time.js
@@ -1,6 +1,17 @@
-export const getOneHourAhead = () => {
-  // this function generates a string of time one hour ahead of the current time
-  // ex: "1:29 AM Pacific Daylight Time"
+// Takes a javascript date object and converts it to a string in the form of yyyy-mm-dd
+export const toDashSeperatedYYYYMMDDString = (date) => {
+  return date.toJSON().substring(0, 10)
+}
+
+// Returns string of the browser's current default timezone
+// ex: "Mountain Daylight Time"
+export const getDefaultTimezoneString = () => {
+  return /\((.*)\)/.exec(new Date().toString())[1]
+}
+
+// Generates a string formatted to be displayed to the user one hour ahead of the current time
+// ex: "1:29 AM Pacific Daylight Time"
+export const getOneHourAheadDisplayString = () => {
   // declaring new Date() here instead of passing in the code generation time stamp as they should be within 60 seconds of each other and second precision here is not necessary
   const now = new Date()
   const ahead = new Date(now.setHours(now.getHours() + 1))
@@ -18,46 +29,26 @@ export const getOneHourAhead = () => {
   if (mins.length === 1) {
     mins = '0' + mins
   }
-  const timezone = /\((.*)\)/.exec(ahead.toString())[1]
+  const timezone = getDefaultTimezoneString()
 
   return hours + ':' + mins + ' ' + amPM + ' ' + timezone
 }
 
 // getFourteenDaysAgo generates a string formatted date fourteen days ago from present day
 // ex: "2020-07-02"
-export const getFourteenDaysAgo = () => {
+export const getFourteenDaysAgoString = () => {
   var ourDate = new Date()
 
   //Change date picker minimum to be 14 days in the past.
   var pastDate = ourDate.getDate() - 13
   ourDate.setDate(pastDate)
 
-  return getDay(ourDate)
+  return toDashSeperatedYYYYMMDDString(ourDate)
 }
 
-// gets a current timestamp of the UTC time as a string:
-// ex: "2020-07-02"
-export const getUTCDate = () => {
-  return new Date().toJSON().substring(0, 10)
-}
-
-// getDay generates a string formatted date based on a date input
-// ex: "2020-07-16"
-export const getDay = (now = new Date()) => {
-  const year = now.getFullYear().toString()
-  let month = (now.getMonth() + 1).toString()
-
-  if (month.length === 1) {
-    month = '0' + month
-  }
-
-  let day = now.getDate().toString()
-
-  if (day.length === 1) {
-    day = '0' + day
-  }
-
-  return year + '-' + month + '-' + day
+// gets today's date as a string formatted as yyyy-mm-dd
+export const getTodayString = () => {
+  return toDashSeperatedYYYYMMDDString(new Date())
 }
 
 // is this date more than 14 days ago?
@@ -75,4 +66,11 @@ export const dateInFuture = (strChosenDate) => {
   let chosenDate = new Date(strChosenDate)
   let today = new Date()
   return chosenDate > today
+}
+
+// Converts a local yyyy-mm-dd date string to zero UTC offset yyyy-mm-dd date string
+export const localStringToZeroUTCOffsetString = (localDateString) => {
+  const localDate = new Date(localDateString)
+  // toISOString returns date string with zero UTC offset
+  return localDate.toISOString().substring(0, 10)
 }

--- a/frontend/client/styles/screens/code_validations.scss
+++ b/frontend/client/styles/screens/code_validations.scss
@@ -74,10 +74,6 @@
         margin-top: 10px;
       }
 
-      .date-sub-desc {
-        font-weight: 600;
-      }
-
       #date-picker {
         // width is the same as the button
         width: 350px;


### PR DESCRIPTION
- cleaned up time.js a bit 
- created `localStringToZeroUTCOffsetString` to convert local yyyy-mm-dd datestrings to yyyy-mm-dd datestrings with a zero UTC offset, which we now use before sending the date to the server.

Makes use of [toISOString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)

> The toISOString() method returns a string in simplified extended ISO format (ISO 8601), which is always 24 or 27 characters long (YYYY-MM-DDTHH:mm:ss.sssZ or ±YYYYYY-MM-DDTHH:mm:ss.sssZ, respectively). The timezone is always zero UTC offset, as denoted by the suffix "Z".

- Changed the subtext of the Symptom Onset Date input to "Timezone set to <default timezone>" i.e.
<img width="790" alt="Screen Shot 2020-08-03 at 2 00 08 PM" src="https://user-images.githubusercontent.com/13578537/89222107-abf29f00-d591-11ea-8b2f-582570f9aabd.png">

closes https://github.com/covidwatchorg/portal/issues/443