### PR TITLE
Fix "reset password workflow logs user in with magic link without resetting password"

### DIFF
--- a/frontend/client/src/components/NavBar.js
+++ b/frontend/client/src/components/NavBar.js
@@ -55,6 +55,17 @@ const NavBarBase = observer((props) => {
     setRedirect(num)
   }
 
+  // Determines whether to display the navbar as if the user is logged in.
+  // Used to handle the complex cases where the user is technically logged in but we don't want it to seem
+  // that way to them, i.e. for password resets.
+  const displayAsIfLoggedIn = () => {
+    return (
+      props.store.data.user.isSignedIn &&
+      !(props.store.data.user.passwordResetRequested && props.store.data.user.signedInWithEmailLink) &&
+      !props.store.data.user.passwordResetCompletedInCurrentSession
+    )
+  }
+
   const LoggedInIcons = (
     <div id="logged-in-icons-container">
       <div className="avatar_group avatar_text">
@@ -128,12 +139,16 @@ const NavBarBase = observer((props) => {
     <div className="navbarContainer">
       <Link to="/code_validations" className="logo-link">
         <img
-          src={props.store.data.organization.logoBlob ? props.store.data.organization.logoBlob : cwLogo}
+          src={
+            props.store.data.organization.logoBlob && displayAsIfLoggedIn()
+              ? props.store.data.organization.logoBlob
+              : cwLogo
+          }
           id="orgLogo"
           alt={props.store.data.organization.name}
         />
       </Link>
-      {props.store.data.user.firstName ? LoggedInIcons : <div id="logged-in-icons-container" />}
+      {displayAsIfLoggedIn() ? LoggedInIcons : <div id="logged-in-icons-container" />}
     </div>
   )
 })

--- a/frontend/client/src/store/firebase.js
+++ b/frontend/client/src/store/firebase.js
@@ -28,9 +28,10 @@ window.env = process.env.NODE_ENV
 app.initializeApp(config)
 const auth = app.auth()
 const SESSION = app.auth.Auth.Persistence.SESSION
+const NONE = app.auth.Auth.Persistence.NONE
 const db = app.firestore()
 const createUserCallable = app.functions().httpsCallable('createUser')
 const initiatePasswordRecoveryCallable = app.functions().httpsCallable('initiatePasswordRecovery')
 const getVerificationCodeCallable = app.functions().httpsCallable('getVerificationCode')
 
-export { auth, db, SESSION, createUserCallable, initiatePasswordRecoveryCallable, getVerificationCodeCallable }
+export { auth, db, SESSION, NONE, createUserCallable, initiatePasswordRecoveryCallable, getVerificationCodeCallable }

--- a/frontend/client/src/store/index.js
+++ b/frontend/client/src/store/index.js
@@ -5,6 +5,7 @@ import {
   auth,
   db,
   SESSION,
+  NONE,
   createUserCallable,
   initiatePasswordRecoveryCallable,
   getVerificationCodeCallable,
@@ -19,7 +20,6 @@ const createStore = (WrappedComponent) => {
   return class extends React.Component {
     constructor(props) {
       super(props)
-      auth.setPersistence(SESSION)
       this.data = rootStore
       this.__userDocumentListener = null
       this.__userImageListener = null
@@ -44,6 +44,13 @@ const createStore = (WrappedComponent) => {
                   isSignedIn: true,
                   signedInWithEmailLink: this.__signedInWithEmailLink,
                 })
+                // If this is a login triggered by a reset password email that the user clicked, set auth persistence to NONE
+                // so that they cannot escape the non-dismissable dialog and log in by refreshing the page
+                if (updatedUserDocumentSnapshot.data().passwordResetRequested && this.__signedInWithEmailLink) {
+                  auth.setPersistence(NONE)
+                } else {
+                  auth.setPersistence(SESSION)
+                }
                 // If DNE, set up organization listener within this callback,
                 // since it relies on this.data.user.organizationID being set
                 if (this.__organizationDocumentListener === null) {

--- a/frontend/client/src/store/model.js
+++ b/frontend/client/src/store/model.js
@@ -15,9 +15,14 @@ const User = types
     lastName: types.string,
     organizationID: types.string,
     isFirstTimeUser: types.boolean,
+    // NOTE: passwordResetRequested should typically be checked along with signedInWithEmailLink when used in conditionals
+    // e.g. `if (passwordResetRequested && signedInWithEmailLink) ...`
+    // Such conditionals are only met when the user requested a password reset AND they themselves clicked on the
+    // magic link in the email. This protects against attacks where a malicious third party locks a user out of the portal
+    // (or makes it exceedingly difficult to use) by repeatedly entering a legitimate user's email into the `Forgot password?` dialog.
     passwordResetRequested: types.maybe(types.boolean),
-    passwordResetCompletedInCurrentSession: types.maybe(types.boolean), // frontend-only field
     signedInWithEmailLink: types.maybe(types.boolean), // frontend-only field
+    passwordResetCompletedInCurrentSession: types.maybe(types.boolean), // frontend-only field
   })
   .actions((self) => {
     const __update = (updates) => {


### PR DESCRIPTION
Fixes a bug where a user could request a password reset, click the magic link, get the supposed-to-be-un-dismissible reset modal, but then refresh the page and be logged in without ever actually resetting the pwd (see the video link in https://github.com/covidwatchorg/portal/issues/450)

Also fixes the NavBar weirdness (shown at the end of the video linked in https://github.com/covidwatchorg/portal/issues/450), so that at the points during the pwd reset where the user is technically logged in but hasn't completed the process, the navbar appears to them the same as if they were logged out.

closes https://github.com/covidwatchorg/portal/issues/450