### PR TITLE
add bug bounty .txt file to /static

### DIFF
--- a/frontend/security.txt
+++ b/frontend/security.txt
@@ -1,0 +1,1 @@
+OpenBugBounty: https://openbugbounty.org/bugbounty/waynehaber/


### PR DESCRIPTION
A request from @whaber to add this similar to what we just added to the website: https://covidwatch.org/security.txt.

Just adding this file to the `/static` folder so it shouldn't affect any other code in any way.