### PR TITLE
Change auth state persistence to NONE

### DIFF
--- a/frontend/client/src/store/index.js
+++ b/frontend/client/src/store/index.js
@@ -20,6 +20,8 @@ const createStore = (WrappedComponent) => {
   return class extends React.Component {
     constructor(props) {
       super(props)
+      // Set auth persistence to SESSION for development so that every change registered by the hot-reload dev server doesn't log you out
+      auth.setPersistence(process.env.NODE_ENV == 'development' ? SESSION : NONE)
       this.data = rootStore
       this.__userDocumentListener = null
       this.__userImageListener = null
@@ -44,13 +46,6 @@ const createStore = (WrappedComponent) => {
                   isSignedIn: true,
                   signedInWithEmailLink: this.__signedInWithEmailLink,
                 })
-                // If this is a login triggered by a reset password email that the user clicked, set auth persistence to NONE
-                // so that they cannot escape the non-dismissable dialog and log in by refreshing the page
-                if (updatedUserDocumentSnapshot.data().passwordResetRequested && this.__signedInWithEmailLink) {
-                  auth.setPersistence(NONE)
-                } else {
-                  auth.setPersistence(SESSION)
-                }
                 // If DNE, set up organization listener within this callback,
                 // since it relies on this.data.user.organizationID being set
                 if (this.__organizationDocumentListener === null) {

--- a/frontend/client/src/store/model.js
+++ b/frontend/client/src/store/model.js
@@ -142,18 +142,24 @@ const defaultStore = {
 
 let initialStore = defaultStore
 
-// Based on https://egghead.io/lessons/react-store-store-in-local-storage
-if (sessionStorage.getItem('store')) {
-  initialStore = JSON.parse(sessionStorage.getItem('store'))
+// This prevents every change registered by the hot-reload dev server from resetting the store, which aids in development.
+if (process.env.NODE_ENV == 'development') {
+  // Based on https://egghead.io/lessons/react-store-store-in-local-storage
+  if (sessionStorage.getItem('store')) {
+    initialStore = JSON.parse(sessionStorage.getItem('store'))
+  }
 }
 
 const rootStore = Store.create({
   ...initialStore,
 })
 
-// Based on https://egghead.io/lessons/react-store-store-in-local-storage
-onSnapshot(rootStore, (snapshot) => {
-  sessionStorage.setItem('store', JSON.stringify(snapshot))
-})
+// This prevents every change registered by the hot-reload dev server from resetting the store, which aids in development.
+if (process.env.NODE_ENV == 'development') {
+  // Based on https://egghead.io/lessons/react-store-store-in-local-storage
+  onSnapshot(rootStore, (snapshot) => {
+    sessionStorage.setItem('store', JSON.stringify(snapshot))
+  })
+}
 
 export { rootStore, defaultUser, defaultOrganization }


### PR DESCRIPTION
closes https://github.com/covidwatchorg/portal/issues/423

Sets Firebase auth state-persistence to `NONE` and removes `sessionStorage` caching of the mobx `store` for non-development environments. We're keeping these for dev, since otherwise every time the webpack dev server hot-reloads you get logged out, which makes development extremely tedious.

To test:
- `npm run start:test # start the dev server with NODE_ENV=test`
- Login is admin@soylentgreen.com
- Refresh the page and see that you're logged out
- Ctrl-C to stop the dev server
- `npm run start:dev # start the dev server with NODE_ENV=development`
- Login is admin@soylentgreen.com
- Refresh the page and see that you're still logged in