### PR TITLE
Issue #409 Radio Buttons

### DIFF
--- a/frontend/client/styles/screens/code_validations.scss
+++ b/frontend/client/styles/screens/code_validations.scss
@@ -68,9 +68,9 @@
       flex-direction: column;
 
       .radio-input {
-        max-width: 16px;
-        max-height: 16px;
-        transform: scale(1.23);
+        max-width: 20px;
+        max-height: 20px;
+        margin-left: 0px;
         margin-right: 20px;
       }
 


### PR DESCRIPTION
Fixed the issue that made Safari Radio Buttons look distorted at certain zoom levels. Removed the line transform:scale(1.23), which was causing the issue and adjusted the height/width of the buttons, and the margin-left to match the previous style. The radio buttons will look different in various browsers unless we add a significant amount of custom styling to normalize it across all browsers. View this link for reference --->[Link][https://www.456bereastreet.com/lab/styling-form-controls-revisited/radio-button/](url).