### PR TITLE
Disable react dev tools

### DIFF
--- a/frontend/client/index.js
+++ b/frontend/client/index.js
@@ -3,10 +3,16 @@ import React from 'react'
 import App from './App'
 import * as Sentry from '@sentry/react'
 import './styles/index.scss'
+import { disableReactDevTools } from '@fvilers/disable-react-devtools'
 
 Sentry.init({
   dsn: 'https://13821d959c3a4f10944bb8ef579d034d@o410040.ingest.sentry.io/5283616',
   environment: window.env,
 })
+
+// Disable react dev tools to make it difficult for hackers to access the store and explore protected routes
+if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
+  disableReactDevTools()
+}
 
 ReactDOM.render(<App />, document.getElementById('root'))

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -55,7 +55,6 @@ const SignInFormBase = observer(
     trySignInWithEmailLink = async () => {
       // Based on https://firebase.google.com/docs/auth/web/email-link-auth
       if (this.props.store.isSignInWithEmailLink(window.location.href)) {
-        Logging.log('signInWithEmailLink detected')
         // Get the email if available. This should be available if the user completes
         // the flow on the same device where they started it.
         var email = window.localStorage.getItem('emailForSignIn')
@@ -74,7 +73,6 @@ const SignInFormBase = observer(
             // result.additionalUserInfo.profile == null
             // You can check if the user is new or existing:
             // result.additionalUserInfo.isNewUser
-            Logging.log('Logged in via signInWithEmailLink')
           })
           .catch((err) => {
             // Some error occurred, you can inspect the code: error.code

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -44,7 +44,7 @@ const SettingsBase = observer((props) => {
 
   const saveImage = async () => {
     if (imgUploader.current.files.length == 0) {
-      Logging.log('no image uploaded')
+      // No image uploaded
       return
     }
 

--- a/frontend/client/src/store/index.js
+++ b/frontend/client/src/store/index.js
@@ -182,7 +182,6 @@ const createStore = (WrappedComponent) => {
     async createUser(newUser) {
       try {
         const result = await createUserCallable(newUser)
-        Logging.log(`Created new user: ${JSON.stringify(result.data)}`)
         return result.data
       } catch (err) {
         Logging.log(err)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1504,6 +1504,11 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.41.tgz",
       "integrity": "sha512-XcdMT5PSZHiuf7LJIhzKIe+RyYa25S3LHRRvLnZc6iFjwXkrSDJ8J/HWO6VT8d2ZTbawp3VcLEjRF/VN8glCrA=="
     },
+    "@fvilers/disable-react-devtools": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@fvilers/disable-react-devtools/-/disable-react-devtools-1.1.1.tgz",
+      "integrity": "sha512-TUm3qD6bDVVMi84lyigwikkB7SeE8tYwkKsfG+C+2ZDX0mMq0oi7547rRactKbew/JoDgsSE+olitkfaYzUsDw=="
+    },
     "@grpc/grpc-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.8.1.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/runtime": "^7.9.2",
     "@date-io/date-fns": "^2.6.1",
+    "@fvilers/disable-react-devtools": "^1.1.1",
     "@material-ui/core": "^4.9.14",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/pickers": "^3.2.10",


### PR DESCRIPTION
closes https://github.com/covidwatchorg/portal/issues/481

Also removes some unnecessary logging. A truly motivated attacker could likely still figure out how to modify store state directly, i.e. https://blog.jscrambler.com/the-most-effective-way-to-protect-client-side-javascript-applications/. However given the very limited damage they could do (they could only see protected routes client-side, not access/modify protected data, I think this is enough protection for the time being.