### PR TITLE
Mobile menu text size fix

### DIFF
--- a/frontend/client/styles/components/navbar.scss
+++ b/frontend/client/styles/components/navbar.scss
@@ -40,7 +40,7 @@
 #menu-appbar {
   .menu-link {
     font-family: 'Montserrat';
-    font-size: 18px;
+    font-size: 1.2em;
     font-weight: 500;
     margin-top: 14px;
     padding-left: 30px;


### PR DESCRIPTION
Resolves #483  
  
Changed font size to 1.2em to scale better on smaller devices.
  
New Iphone 5/5s menu view  
  
![image](https://user-images.githubusercontent.com/56734437/90058965-7136e800-dcb0-11ea-94b2-fd1fd3bded83.png)  
  
Iphone X view  
  
![image](https://user-images.githubusercontent.com/56734437/90058978-785df600-dcb0-11ea-9753-bdd9d992ab9f.png)
