### PR TITLE
Run workflow job based on files committed

### DIFF
--- a/.github/actions/check-diff/action.yml
+++ b/.github/actions/check-diff/action.yml
@@ -17,6 +17,7 @@ runs:
           diff=$(git diff --name-only HEAD HEAD~1)
           echo $diff
           for dir in frontend cloud-functions; do
+            echo $dir
             # Set the frontend or cloud-functions output if that directory
             # or config/ changed
              if echo $diff | grep -q "$dir\|config"; then

--- a/.github/actions/check-diff/action.yml
+++ b/.github/actions/check-diff/action.yml
@@ -15,6 +15,7 @@ runs:
         run : |
           # Use git diff to see the files altered by previous commit
           diff=$(git diff --name-only HEAD HEAD~1)
+          echo $diff
           for dir in frontend cloud-functions; do
             # Set the frontend or cloud-functions output if that directory
             # or config/ changed

--- a/.github/actions/check-diff/action.yml
+++ b/.github/actions/check-diff/action.yml
@@ -1,11 +1,11 @@
 name: 'check-diff'
-description: "Determines if which directories were changed in the previous commit / PR "
+description: "Determines which directories were changed in the previous commit / PR "
 outputs:
   frontend: 
-    description: "set only if frontend/ or config/ changed in previous commit"
+    description: "Set only if frontend/ or config/ changed in previous commit"
     value: ${{ steps.check-diff.outputs.frontend }}
   cloud-functions:
-    description: "set only if cloud-functions/ or config/ changed in previous commit"
+    description: "Set only if cloud-functions/ or config/ changed in previous commit"
     value: ${{ steps.check-diff.outputs.cloud-functions }}
 
 runs:

--- a/.github/actions/check-diff/action.yml
+++ b/.github/actions/check-diff/action.yml
@@ -1,0 +1,25 @@
+name: 'check-diff'
+description: "Determines if which directories were changed in the previous commit / PR "
+outputs:
+  frontend: 
+    description: "set only if frontend/ or config/ changed in previous commit"
+    value: ${{ steps.check-diff.outputs.frontend }}
+  cloud-functions:
+    description: "set only if cloud-functions/ or config/ changed in previous commit"
+    value: ${{ steps.check-diff.outputs.cloud-functions }}
+
+runs:
+  using: "composite"
+  steps:
+      - id: check-diff
+        run : |
+          # Use git diff to see the files altered by previous commit
+          diff=$(git diff --name-only HEAD HEAD~1)
+          for dir in frontend cloud-functions; do
+            # Set the frontend or cloud-functions output if that directory
+            # or config/ changed
+             if echo $diff | grep -q "$dir\|config"; then
+               echo "::set-output name=$dir::true"
+             fi 
+          done
+        shell: bash 

--- a/.github/actions/check-diff/action.yml
+++ b/.github/actions/check-diff/action.yml
@@ -19,6 +19,7 @@ runs:
             # Set the frontend or cloud-functions output if that directory
             # or config/ changed
              if echo $diff | grep -q "$dir\|config"; then
+               echo "setting output $dir"
                echo "::set-output name=$dir::true"
              fi 
           done

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,6 +129,7 @@ jobs:
   frontend-tests:
     name: Run Frontend Tests
     runs-on: ubuntu-latest
+    if: needs.check-diff.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 12.x

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,9 +7,33 @@ on:
     branches: [master, dev]
 
 jobs:
+  check-diff:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      frontend: ${{ steps.check-diff.outputs.frontend }}
+      cloud-functions: ${{ steps.check-diff.outputs.cloud-functions }}
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - id: check-diff
+        run : |
+           diff=$(git diff --name-only HEAD HEAD~1)
+           for dir in frontend cloud-functions; do
+              if echo $diff | grep -q "$dir\|config"; then
+                echo "::set-output name=$dir::true"
+              fi 
+           done
+
   build-frontend:
     name: Build Frontend App
     runs-on: ubuntu-latest
+    needs: check-diff
+    if: needs.check-diff.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 12.x
@@ -28,6 +52,8 @@ jobs:
   build-firebase:
     name: Build Firebase
     runs-on: ubuntu-latest
+    needs: check-diff
+    if: needs.check-diff.outputs.cloud-functions == 'true'
     steps:
       - uses: actions/checkout@v2
       - name: Install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,25 +9,17 @@ on:
 jobs:
   check-diff:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
+    # Map outputs from check-diff step to job outputs
     outputs:
       frontend: ${{ steps.check-diff.outputs.frontend }}
       cloud-functions: ${{ steps.check-diff.outputs.cloud-functions }}
-
     steps:
-      - name: Checkout master
+      - name: Checkout branch
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
       - id: check-diff
-        run : |
-           diff=$(git diff --name-only HEAD HEAD~1)
-           for dir in frontend cloud-functions; do
-              if echo $diff | grep -q "$dir\|config"; then
-                echo "::set-output name=$dir::true"
-              fi 
-           done
+        uses: ./.github/actions/check-diff
 
   build-frontend:
     name: Build Frontend App
@@ -129,7 +121,7 @@ jobs:
   frontend-tests:
     name: Run Frontend Tests
     runs-on: ubuntu-latest
-    if: needs.check-diff.outputs.frontend == 'true'
+    needs: build-frontend
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 12.x

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,33 @@ on:
     branches: [dev, master]
 
 jobs:
+  check-diff:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      frontend: ${{ steps.check-diff.outputs.frontend }}
+      cloud-functions: ${{ steps.check-diff.outputs.cloud-functions }}
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - id: check-diff
+        run : |
+           diff=$(git diff --name-only HEAD HEAD~1)
+           for dir in frontend cloud-functions; do
+              if echo $diff | grep -q "$dir\|config"; then
+                echo "::set-output name=$dir::true"
+              fi 
+           done
+
   deploy-frontend:
     name: Build and Deploy Frontend App
+    needs: check-diff
     runs-on: ubuntu-latest
+    if: needs.check-diff.outputs.frontend == 'true'
 
     steps:
       - uses: actions/checkout@v2
@@ -57,7 +81,10 @@ jobs:
 
   build-firebase:
     name: Build Firebase
+    needs: check-diff
     runs-on: ubuntu-latest
+    if: needs.check-diff.outputs.cloud-functions == 'true'
+
     steps:
       - uses: actions/checkout@v2
       - name: Install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,42 +10,31 @@ on:
 jobs:
   check-diff:
     runs-on: ubuntu-latest
-    # Map a step output to a job output
+    # Map outputs from check-diff step to job outputs
     outputs:
       frontend: ${{ steps.check-diff.outputs.frontend }}
       cloud-functions: ${{ steps.check-diff.outputs.cloud-functions }}
-
     steps:
-      - name: Checkout master
+      - name: Checkout branch
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
       - id: check-diff
-        run : |
-           diff=$(git diff --name-only HEAD HEAD~1)
-           for dir in frontend cloud-functions; do
-              if echo $diff | grep -q "$dir\|config"; then
-                echo "::set-output name=$dir::true"
-              fi 
-           done
+        uses: ./.github/actions/check-diff
 
   deploy-frontend:
     name: Build and Deploy Frontend App
     needs: check-diff
     runs-on: ubuntu-latest
     if: needs.check-diff.outputs.frontend == 'true'
-
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-
       - name: Build node app for staging
         if: github.ref == 'refs/heads/dev'
         working-directory: frontend
@@ -55,7 +44,6 @@ jobs:
           npm ci
           npm run init
           npm run build:staging
-
       - name: Build node app for prod
         if: github.ref == 'refs/heads/master'
         working-directory: frontend
@@ -65,14 +53,12 @@ jobs:
           npm ci
           npm run init
           npm run build
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
-
       - name: Deploy to S3
         working-directory: frontend
         run: |
@@ -84,7 +70,6 @@ jobs:
     needs: check-diff
     runs-on: ubuntu-latest
     if: needs.check-diff.outputs.cloud-functions == 'true'
-
     steps:
       - uses: actions/checkout@v2
       - name: Install

--- a/config/functions.config.dev.js
+++ b/config/functions.config.dev.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: "https://dev.adminapi.verification.covidwatch.org",
+    url: process.env.VERIFICATION_SERVER_URL,
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.dev.js
+++ b/config/functions.config.dev.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: process.env.VERIFICATION_SERVER_URL,
+      url: "https://dev.adminapi.verification.covidwatch.org",
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.dev.js
+++ b/config/functions.config.dev.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: process.env.VERIFICATION_SERVER_URL,
+    url: "https://dev.adminapi.verification.covidwatch.org",
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.prod.js
+++ b/config/functions.config.prod.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: "test",
+    url: process.env.VERIFICATION_SERVER_URL,
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.prod.js
+++ b/config/functions.config.prod.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: process.env.VERIFICATION_SERVER_URL,
+    url: "test",
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -20,6 +20,7 @@ const INITIAL_STATE = {
   toastMessage: '',
 }
 
+// Test comment
 const SignInFormBase = observer(
   class SignInFormBase extends React.Component {
     constructor(props) {

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -20,7 +20,6 @@ const INITIAL_STATE = {
   toastMessage: '',
 }
 
-// Test comment
 const SignInFormBase = observer(
   class SignInFormBase extends React.Component {
     constructor(props) {

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -118,7 +118,7 @@ const SignInFormBase = observer(
             <label className="small-text" htmlFor="email">
               Email Address
             </label>
-            <input onChange={this.onChange('email')} type="email" id="email" name="email" ref={this.emailInput}/>
+            <input onChange={this.onChange('email')} type="email" id="email" name="email" ref={this.emailInput} />
             <label className="small-text" htmlFor="password">
               Password
             </label>


### PR DESCRIPTION
Closes #480 

GitHub Actions actually makes this not too bad to do using [outputs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs). 

We add another job in both workflows called `check-diff` that runs before all other jobs. `check-diff` determines if `frontend/` or `cloud-functions/` was altered by the previous commit. If one of the directories was altered, an output with its name is set  (see [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjobs_idoutputs) for a general example).  Later jobs check the outputs and only execute if the correct output was set. The fronted jobs will only run if `frontend/` or `config/` changed in the previous commit and the firebase jobs only run if `cloud-functions/` or `config/` changed in the previous commit. 

For example, in [this run](https://github.com/covidwatchorg/portal/actions/runs/206613171), I only changed the workflow file, so none of the frontend or cloud functions jobs ran. 

### Updates
`check-diff` is now its own custom action, that is used in both workflows. 