### PR TITLE
Temporary Manage Members Mobile Screen for Friday

### DIFF
--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -118,7 +118,7 @@ const SignInFormBase = observer(
             <label className="small-text" htmlFor="email">
               Email Address
             </label>
-            <input onChange={this.onChange('email')} type="email" id="email" name="email" ref={this.emailInput}/>
+            <input onChange={this.onChange('email')} type="email" id="email" name="email" ref={this.emailInput} />
             <label className="small-text" htmlFor="password">
               Password
             </label>

--- a/frontend/client/src/screens/ManageTeams.js
+++ b/frontend/client/src/screens/ManageTeams.js
@@ -107,7 +107,7 @@ const ManageTeamsBase = observer((props) => {
         <img src={addMember} alt="" />
         <span className="add-button-text">Add Member</span>
       </button>
-      <p className='mobile-msg'>Use desktop to view members.</p>
+      <p className="mobile-msg">Use desktop to view members.</p>
       <AddMemberModal
         hidden={!showAddMemberModal}
         onClose={onAddMemberCancel}

--- a/frontend/client/src/screens/ManageTeams.js
+++ b/frontend/client/src/screens/ManageTeams.js
@@ -107,6 +107,7 @@ const ManageTeamsBase = observer((props) => {
         <img src={addMember} alt="" />
         <span className="add-button-text">Add Member</span>
       </button>
+      <p className='mobile-msg'>Use desktop to view members.</p>
       <AddMemberModal
         hidden={!showAddMemberModal}
         onClose={onAddMemberCancel}

--- a/frontend/client/styles/components/navbar.scss
+++ b/frontend/client/styles/components/navbar.scss
@@ -49,7 +49,7 @@
   }
 
   @include media('<=phone') {
-    #manage-members, #mobile-app-settings {
+    #mobile-app-settings {
       display: none;
     }
   }

--- a/frontend/client/styles/screens/add_member_modal.scss
+++ b/frontend/client/styles/screens/add_member_modal.scss
@@ -31,7 +31,7 @@
   .custom-select:after {
     content: url('../../assets/arrow-down.svg');
     position: relative;
-    left: 320px;
+    left: 92%;
     top: -31px;
     background-color: transparent;
     pointer-events: none;

--- a/frontend/client/styles/screens/add_member_modal.scss
+++ b/frontend/client/styles/screens/add_member_modal.scss
@@ -1,4 +1,5 @@
 @import '../color.scss';
+@import '../include-media';
 
 .add-member-modal-container {
   height: 600px;
@@ -6,6 +7,10 @@
 
   @media screen and (max-height: 634px) {
     overflow: scroll;
+  }
+
+  @include media('<=phone') {
+    max-height: 550px;
   }
 }
 
@@ -18,6 +23,10 @@
     border-radius: 7px;
     font-size: 16px;
     padding-left: 20px;
+
+    @include media('<=phone') {
+      width: 100%;
+    }
   }
   .custom-select:after {
     content: url('../../assets/arrow-down.svg');

--- a/frontend/client/styles/screens/manage_teams.scss
+++ b/frontend/client/styles/screens/manage_teams.scss
@@ -18,11 +18,10 @@
 }
 
 .mobile-msg {
-  display: none;
+  align-self: center;
 
-  @include media('<=phone') {
-    display: block;
-    align-self: center;
+  @include media('>phone') {
+    display: none;
   }
 }
 

--- a/frontend/client/styles/screens/manage_teams.scss
+++ b/frontend/client/styles/screens/manage_teams.scss
@@ -1,8 +1,13 @@
 @import '../color.scss';
+@import '../include-media';
 
 .add-member-button {
   align-self: flex-start;
   margin: 22px 0px 12px 0px;
+
+  @include media('<=phone') {
+    align-self: center;
+  }
 
   .add-button-text {
     margin-left: 12px;
@@ -12,11 +17,25 @@
   cursor: pointer;
 }
 
+.mobile-msg {
+  display: none;
+
+  @include media('<=phone') {
+    display: block;
+    align-self: center;
+  }
+}
+
 table {
   border-spacing: 0;
   width: 100%;
   border: 1px solid $darkMediumGray;
   border-collapse: collapse;
+
+  @include media('<=phone') {
+    display: none;
+  }
+
   tr {
     height: 45px;
     th {
@@ -84,6 +103,11 @@ table {
   margin: 33px 0;
   font-weight: 600;
   line-height: 18px;
+
+  @include media('<=phone') {
+    display: none;
+  }
+
   .pages-container {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Members grid hidden on mobile until further refactoring can be made. Still able to add members, displays message to use desktop if you want to see members grid. Pic below:  
  
![image](https://user-images.githubusercontent.com/56734437/90151327-99782280-dd54-11ea-93c3-355ddd37ee4f.png)  
  
Also added link to manage members screen back to mobile nav menu.
