### PR TITLE
prevent name change save of one char

### DIFF
--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -50,9 +50,25 @@ const SettingsBase = observer((props) => {
     if (event.target.name == 'prefix') {
       props.store.updateUser({ prefix: event.target.value })
     } else if (event.target.name == 'firstName') {
-      props.store.updateUser({ firstName: event.target.value })
+      if (event.target.value.length < 1) {
+        setToastInfo({
+          success: false,
+          msg: 'First name must be at least one character',
+        })
+        toastRef.current.show()
+      } else  {
+        props.store.updateUser({ firstName: event.target.value })
+      }
     } else if (event.target.name == 'lastName') {
-      props.store.updateUser({ lastName: event.target.value })
+      if (event.target.value.length < 1) {
+        setToastInfo({
+          success: false,
+          msg: 'Last name must be at least one character',
+        })
+        toastRef.current.show()
+      } else {
+        props.store.updateUser({ lastName: event.target.value })
+      }
     }
   }
 
@@ -224,7 +240,7 @@ const SettingsBase = observer((props) => {
                 required
                 aria-required="true"
                 onChange={onChange}
-                value={props.store.data.user.firstName}
+                defaultValue={props.store.data.user.firstName}
               ></input>
               <label htmlFor="email">Email Address</label>
               <input


### PR DESCRIPTION
closes #490 

Note that the user is able to delete all characters from the `firstName` and `lastName` fields but the store is only altered if the field has one or more characters.  Meaning that a user can remove all characters, see an error message, but the name that is saved is a single character if they navigate away from the page.

I played with a few options like forcing a single character to remain in the input fields but this seemed like a bad UX if the user for some reason wants to delete all characters and start over, it prevents them from doing so and is a little jerky.