### PR TITLE
Custom Safari desktop date picker

### DIFF
--- a/frontend/client/__tests__/code_validations.test.js
+++ b/frontend/client/__tests__/code_validations.test.js
@@ -4,9 +4,8 @@ import { rootStore } from '../src/store/model'
 import { createStore } from '../src/store'
 import CodeValidations from '../src/screens/CodeValidations'
 import PendingOperationButton from '../src/components/PendingOperationButton'
-import Toast from '../src/components/Toast'
 import { getVerificationCodeCallable } from '../src/store/firebase'
-import { toDashSeperatedYYYYMMDDString, getTodayString } from '../src/util/time'
+import { getTodayString } from '../src/util/time'
 
 // Mock Redirect to avoid router error
 jest.mock('react-router-dom', () => {
@@ -49,25 +48,27 @@ describe('Code Validations', () => {
   test.each([
     [-16, 'Date cannot be more than 14 days ago'],
     [5, 'Date cannot be in the future'],
-  ])('does not allow dates %i days away', (numDaysAway, expectedMessage) => {
+  ])('does not allow dates %i days away', (numDaysAway) => {
     const wrapped = mount(<CodeVWrapped />)
 
     var date = new Date()
     date.setDate(date.getDate() + numDaysAway)
 
-    wrapped.find('#date-picker').simulate('change', {
-      target: {
-        value: toDashSeperatedYYYYMMDDString(date),
-        classList: {
-          add: () => {},
-          remove: () => {},
+    wrapped
+      .find('#date-picker')
+      .at(1)
+      .simulate('change', {
+        target: {
+          value: date,
+          classList: {
+            add: () => {},
+            remove: () => {},
+          },
         },
-      },
-    })
+      })
 
     // Ensure Generate Code button is disabled and Toast has the correct error message
     expect(wrapped.find(PendingOperationButton).at(0).props().disabled).toBe(true)
-    expect(wrapped.find(Toast).at(0).props().message).toBe(expectedMessage)
   })
 
   it('can generate code with correct options', async () => {
@@ -75,22 +76,21 @@ describe('Code Validations', () => {
     // JsDOM doesn't handle this well and document.getElementById returns null in the tests without this mock
     Object.defineProperty(document, 'getElementById', {
       value: () => {
-        return { classList: { toggle: () => {} } }
+        return { classList: { toggle: () => {}, add: () => {}, remove: () => {} } }
       },
     })
 
     var wrapped = mount(<CodeVWrapped />)
 
     // Pick valid date
-    wrapped.find('#date-picker').simulate('change', {
-      target: {
-        value: getTodayString(),
-        classList: {
-          add: () => {},
-          remove: () => {},
+    wrapped
+      .find('#date-picker')
+      .at(1)
+      .simulate('change', {
+        target: {
+          value: getTodayString(),
         },
-      },
-    })
+      })
     // Can't generate a code with a date, even if it's valid
     expect(wrapped.find(PendingOperationButton).at(0).props().disabled).toBe(true)
 

--- a/frontend/client/__tests__/code_validations.test.js
+++ b/frontend/client/__tests__/code_validations.test.js
@@ -44,33 +44,6 @@ describe('Code Validations', () => {
     expect(wrapped.find(PendingOperationButton).at(0).props().disabled).toBe(true)
   })
 
-  // Dates more than 14 days in the past or in the future are invalid
-  test.each([
-    [-16, 'Date cannot be more than 14 days ago'],
-    [5, 'Date cannot be in the future'],
-  ])('does not allow dates %i days away', (numDaysAway) => {
-    const wrapped = mount(<CodeVWrapped />)
-
-    var date = new Date()
-    date.setDate(date.getDate() + numDaysAway)
-
-    wrapped
-      .find('#date-picker')
-      .at(1)
-      .simulate('change', {
-        target: {
-          value: date,
-          classList: {
-            add: () => {},
-            remove: () => {},
-          },
-        },
-      })
-
-    // Ensure Generate Code button is disabled and Toast has the correct error message
-    expect(wrapped.find(PendingOperationButton).at(0).props().disabled).toBe(true)
-  })
-
   it('can generate code with correct options', async () => {
     // Mock document.getElementById used by the CodeValidations component.
     // JsDOM doesn't handle this well and document.getElementById returns null in the tests without this mock

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -199,6 +199,7 @@ const CodeValidationsBase = observer((props) => {
               min={getFourteenDaysAgoString()}
               max={getTodayString()}
               onChange={handleDate}
+              placeholder="mm-dd-yyyy"
             ></input>
           </form>
           <p className="date-desc">Time zone set to {getDefaultTimezoneString()}</p>

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -11,8 +11,6 @@ import DatePicker from 'react-datepicker'
 
 import {
   getOneHourAheadDisplayString,
-  moreThanFourteenDaysAgo,
-  dateInFuture,
   getDefaultTimezoneString,
   localStringToZeroUTCOffsetString,
   toDashSeperatedYYYYMMDDString,
@@ -64,7 +62,8 @@ const CodeValidationsBase = observer((props) => {
     try {
       let code = await props.store.getVerificationCode({
         testType: testType,
-        symptomDate: symptomDateYYYYMMDD === '' ? symptomDateYYYYMMDD : localStringToZeroUTCOffsetString(symptomDateYYYYMMDD),
+        symptomDate:
+          symptomDateYYYYMMDD === '' ? symptomDateYYYYMMDD : localStringToZeroUTCOffsetString(symptomDateYYYYMMDD),
       })
       setCode(code.data.split('').join(''))
       codeTimeStamp()
@@ -90,26 +89,8 @@ const CodeValidationsBase = observer((props) => {
     const selectedDate = toDashSeperatedYYYYMMDDString(date)
     document.getElementById('date-picker').classList.add('with-value')
     document.getElementById('date-picker').classList.remove('no-value')
-
-    // does not allow symptomDate in state to be set if date selected is more than 14 days ago or in the future
-    if (moreThanFourteenDaysAgo(selectedDate)) {
-      setDateInvalid(true)
-      setToastInfo({
-        success: false,
-        msg: 'Date cannot be more than 14 days ago',
-      })
-      confirmedToast.current.show()
-    } else if (dateInFuture(selectedDate)) {
-      setDateInvalid(true)
-      setToastInfo({
-        success: false,
-        msg: 'Date cannot be in the future',
-      })
-      confirmedToast.current.show()
-    } else {
-      setDateInvalid(false)
-      setSymptomDateYYYYMMDD(selectedDate)
-    }
+    setDateInvalid(false)
+    setSymptomDateYYYYMMDD(selectedDate)
     updateButtonDisabled()
   }
 
@@ -143,7 +124,7 @@ const CodeValidationsBase = observer((props) => {
       selected={symptomDateObject}
       minDate={getFourteenDaysAgoDate()}
       maxDate={new Date()}
-      onChange={(date) => handleDate(date)}
+      onChange={handleDate}
       placeholderText="Choose a date in last 14 days"
     />
   )

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -84,8 +84,8 @@ const CodeValidationsBase = observer((props) => {
     updateButtonDisabled()
   }
 
-  const handleDate = (date) => {    
-    if(date) {
+  const handleDate = (date) => {
+    if (date) {
       setSymptomDateObject(date)
       const selectedDate = toDashSeperatedYYYYMMDDString(date)
       setDateInvalid(false)

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -7,6 +7,7 @@ import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import PendingOperationButton from '../components/PendingOperationButton'
 import Clock from '../../assets/clock.svg'
+import DatePicker from 'react-datepicker'
 import {
   getOneHourAheadDisplayString,
   getFourteenDaysAgoString,
@@ -20,233 +21,312 @@ import {
 const codePlaceholder = '00000000'
 
 const CodeValidationsBase = observer((props) => {
-  const [testType, setTestType] = useState('')
-  const [symptomDate, setSymptomDate] = useState('')
-  const [dateInvalid, setDateInvalid] = useState(false)
-  const [needsReset, setNeedsReset] = useState(false)
-  const [code, setCode] = useState(codePlaceholder)
-  const [buttonDisabled, setButtonDisabled] = useState(true)
-  const [expirationTime, setExpirationTime] = useState('')
-  const [timeLeft, setTimeLeft] = useState(60)
-  const [toastInfo, setToastInfo] = useState({
-    success: false,
-    msg: '',
-  })
+                                                  const [testType, setTestType] = useState('')
+                                                  const [symptomDate, setSymptomDate] = useState('')
+                                                  const [dateInvalid, setDateInvalid] = useState(false)
+                                                  const [needsReset, setNeedsReset] = useState(false)
+                                                  const [code, setCode] = useState(codePlaceholder)
+                                                  const [buttonDisabled, setButtonDisabled] = useState(true)
+                                                  const [expirationTime, setExpirationTime] = useState('')
+                                                  const [timeLeft, setTimeLeft] = useState(60)
+                                                  const [startDate, setStartDate] = useState(new Date())
+                                                  const [toastInfo, setToastInfo] = useState({
+                                                    success: false,
+                                                    msg: '',
+                                                  })
 
-  let confirmedToast = React.createRef()
+                                                  let confirmedToast = React.createRef()
 
-  useEffect(() => {
-    updateButtonDisabled()
-  })
+                                                  useEffect(() => {
+                                                    updateButtonDisabled()
+                                                  })
 
-  // Updates the buttonDisabled variable state based on other state variables
-  const updateButtonDisabled = () => {
-    if (needsReset || testType === '' || dateInvalid) {
-      setButtonDisabled(true)
-    } else {
-      setButtonDisabled(false)
-    }
-  }
+                                                  // Updates the buttonDisabled variable state based on other state variables
+                                                  const updateButtonDisabled = () => {
+                                                    if (needsReset || testType === '' || dateInvalid) {
+                                                      setButtonDisabled(true)
+                                                    } else {
+                                                      setButtonDisabled(false)
+                                                    }
+                                                  }
 
-  const countdown = (num = 60) => {
-    setTimeout(() => {
-      if (num > 0 && document.getElementById('code-box').classList.contains('code-generated')) {
-        setTimeLeft(num - 1)
-        countdown(num - 1)
-      }
-    }, 60000)
-  }
+                                                  const countdown = (num = 60) => {
+                                                    setTimeout(() => {
+                                                      if (
+                                                        num > 0 &&
+                                                        document
+                                                          .getElementById('code-box')
+                                                          .classList.contains('code-generated')
+                                                      ) {
+                                                        setTimeLeft(num - 1)
+                                                        countdown(num - 1)
+                                                      }
+                                                    }, 60000)
+                                                  }
 
-  const genNewCode = async () => {
-    try {
-      let code = await props.store.getVerificationCode({
-        testType: testType,
-        symptomDate: symptomDate === '' ? symptomDate : localStringToZeroUTCOffsetString(symptomDate),
-      })
-      setCode(code.data.split('').join(''))
-      codeTimeStamp()
-      setNeedsReset(true)
-      updateButtonDisabled()
-      countdown()
-    } catch (err) {
-      setToastInfo({ success: false, msg: 'Could not generate new code, please try again' })
-      confirmedToast.current.show()
-    }
-  }
+                                                  const genNewCode = async () => {
+                                                    try {
+                                                      let code = await props.store.getVerificationCode({
+                                                        testType: testType,
+                                                        symptomDate:
+                                                          symptomDate === ''
+                                                            ? symptomDate
+                                                            : localStringToZeroUTCOffsetString(symptomDate),
+                                                      })
+                                                      setCode(code.data.split('').join(''))
+                                                      codeTimeStamp()
+                                                      setNeedsReset(true)
+                                                      updateButtonDisabled()
+                                                      countdown()
+                                                    } catch (err) {
+                                                      setToastInfo({
+                                                        success: false,
+                                                        msg: 'Could not generate new code, please try again',
+                                                      })
+                                                      confirmedToast.current.show()
+                                                    }
+                                                  }
 
-  const handleRadio = (e) => {
-    setTestType(e.target.value)
-    updateButtonDisabled()
-  }
+                                                  const handleRadio = (e) => {
+                                                    setTestType(e.target.value)
+                                                    updateButtonDisabled()
+                                                  }
 
-  const handleDate = (e) => {
-    e.target.classList.add('with-value')
-    e.target.classList.remove('no-value')
+                                                  const handleDate = (e) => {
+                                                    e.target.classList.add('with-value')
+                                                    e.target.classList.remove('no-value')
 
-    // does not allow symptomDate in state to be set if date selected is more than 14 days ago or in the future
-    if (moreThanFourteenDaysAgo(e.target.value)) {
-      setDateInvalid(true)
-      setToastInfo({ success: false, msg: 'Date cannot be more than 14 days ago' })
-      confirmedToast.current.show()
-    } else if (dateInFuture(e.target.value)) {
-      setDateInvalid(true)
-      setToastInfo({ success: false, msg: 'Date cannot be in the future' })
-      confirmedToast.current.show()
-    } else {
-      setDateInvalid(false)
-      setSymptomDate(e.target.value)
-    }
-    updateButtonDisabled()
-  }
+                                                    // does not allow symptomDate in state to be set if date selected is more than 14 days ago or in the future
+                                                    if (moreThanFourteenDaysAgo(e.target.value)) {
+                                                      setDateInvalid(true)
+                                                      setToastInfo({
+                                                        success: false,
+                                                        msg: 'Date cannot be more than 14 days ago',
+                                                      })
+                                                      confirmedToast.current.show()
+                                                    } else if (dateInFuture(e.target.value)) {
+                                                      setDateInvalid(true)
+                                                      setToastInfo({
+                                                        success: false,
+                                                        msg: 'Date cannot be in the future',
+                                                      })
+                                                      confirmedToast.current.show()
+                                                    } else {
+                                                      setDateInvalid(false)
+                                                      setSymptomDate(e.target.value)
+                                                    }
+                                                    updateButtonDisabled()
+                                                  }
 
-  const resetState = () => {
-    document.getElementById('radio-form').reset()
-    document.getElementById('date-form').reset()
-    document.getElementById('date-picker').classList.remove('with-value')
-    document.getElementById('date-picker').classList.add('no-value')
-    document.getElementById('code-box').classList.toggle('with-value')
-    document.getElementById('code-box').classList.toggle('no-value')
-    document.getElementById('code-box').classList.toggle('code-generated')
-    setCode(codePlaceholder)
-    setSymptomDate('')
-    setTestType('')
-    setTimeLeft(60)
-    setNeedsReset(false)
-    setDateInvalid(false)
-    updateButtonDisabled()
-  }
+                                                  const resetState = () => {
+                                                    document.getElementById('radio-form').reset()
+                                                    document.getElementById('date-form').reset()
+                                                    document
+                                                      .getElementById('date-picker')
+                                                      .classList.remove('with-value')
+                                                    document.getElementById('date-picker').classList.add('no-value')
+                                                    document.getElementById('code-box').classList.toggle('with-value')
+                                                    document.getElementById('code-box').classList.toggle('no-value')
+                                                    document
+                                                      .getElementById('code-box')
+                                                      .classList.toggle('code-generated')
+                                                    setCode(codePlaceholder)
+                                                    setSymptomDate('')
+                                                    setTestType('')
+                                                    setTimeLeft(60)
+                                                    setNeedsReset(false)
+                                                    setDateInvalid(false)
+                                                    updateButtonDisabled()
+                                                  }
 
-  const codeTimeStamp = () => {
-    // since this is nearly the same moment that a code is generated, we also make the code text black (this assumes the API call will never fail)
-    document.getElementById('code-box').classList.toggle('with-value')
-    document.getElementById('code-box').classList.toggle('no-value')
-    document.getElementById('code-box').classList.toggle('code-generated')
-    setExpirationTime(getOneHourAheadDisplayString())
-  }
+                                                  const codeTimeStamp = () => {
+                                                    // since this is nearly the same moment that a code is generated, we also make the code text black (this assumes the API call will never fail)
+                                                    document.getElementById('code-box').classList.toggle('with-value')
+                                                    document.getElementById('code-box').classList.toggle('no-value')
+                                                    document
+                                                      .getElementById('code-box')
+                                                      .classList.toggle('code-generated')
+                                                    setExpirationTime(getOneHourAheadDisplayString())
+                                                  }
 
-  return !props.store.data.user.isSignedIn ||
-    props.store.data.user.isFirstTimeUser ||
-    (props.store.data.user.passwordResetRequested && props.store.data.user.signedInWithEmailLink) ? (
-    <Redirect to={ROUTES.LANDING} />
-  ) : (
-    <div className="module-container" id="diagnosis-codes">
-      <PageTitle title="Diagnosis Verification Codes" />
-      <h1>Diagnosis Verification Codes</h1>
-      <h2>Submit this form when you are prepared to generate and immediately share the code with a patient.</h2>
-      <div className="row" id="test-type-form">
-        <div className="col-1">
-          <div className="sect-header">COVID-19 Diagnosis</div>
-        </div>
-        <form id="radio-form" className="col-2">
-          <div className="radio">
-            <input
-              className="radio-input"
-              name="testType"
-              type="radio"
-              onClick={handleRadio}
-              id="confirmed"
-              value="confirmed"
-            ></input>
-            <label htmlFor="confirmed" className="col-2-header-container">
-              <div className="col-2-header">Confirmed Positive Test</div>
-              <div className="col-2-sub-header">Confirmed positive result from an official testing source.</div>
-            </label>
-          </div>
+                                                  // simply using basic example from ReactDatePicker docs for now: https://reactdatepicker.com/
+                                                  let datePicker = (
+                                                    <DatePicker
+                                                      selected={startDate}
+                                                      onChange={(date) => setStartDate(date)}
+                                                    />
+                                                  )
 
-          <div className="radio">
-            <input
-              className="radio-input"
-              name="testType"
-              type="radio"
-              onClick={handleRadio}
-              id="likely"
-              value="likely"
-            ></input>
-            <label htmlFor="likely" className="col-2-header-container">
-              <div className="col-2-header">Likely Positive Diagnosis</div>
-              <div className="col-2-sub-header">Clincial diagnosis without a test.</div>
-            </label>
-          </div>
+                                                  return !props.store.data.user.isSignedIn ||
+                                                    props.store.data.user.isFirstTimeUser ||
+                                                    (props.store.data.user.passwordResetRequested &&
+                                                      props.store.data.user.signedInWithEmailLink) ? (
+                                                    <Redirect to={ROUTES.LANDING} />
+                                                  ) : (
+                                                    <div className="module-container" id="diagnosis-codes">
+                                                      <PageTitle title="Diagnosis Verification Codes" />
+                                                      <h1>Diagnosis Verification Codes</h1>
+                                                      <h2>
+                                                        Submit this form when you are prepared to generate and
+                                                        immediately share the code with a patient.
+                                                      </h2>
+                                                      <div className="row" id="test-type-form">
+                                                        <div className="col-1">
+                                                          <div className="sect-header">COVID-19 Diagnosis</div>
+                                                        </div>
+                                                        <form id="radio-form" className="col-2">
+                                                          <div className="radio">
+                                                            <input
+                                                              className="radio-input"
+                                                              name="testType"
+                                                              type="radio"
+                                                              onClick={handleRadio}
+                                                              id="confirmed"
+                                                              value="confirmed"
+                                                            ></input>
+                                                            <label
+                                                              htmlFor="confirmed"
+                                                              className="col-2-header-container"
+                                                            >
+                                                              <div className="col-2-header">
+                                                                Confirmed Positive Test
+                                                              </div>
+                                                              <div className="col-2-sub-header">
+                                                                Confirmed positive result from an official testing
+                                                                source.
+                                                              </div>
+                                                            </label>
+                                                          </div>
 
-          <div className="radio">
-            <input
-              className="radio-input"
-              name="testType"
-              type="radio"
-              onClick={handleRadio}
-              id="negative"
-              value="negative"
-            ></input>
-            <label htmlFor="negative" className="col-2-header-container">
-              <div className="col-2-header">Confirmed Negative Test</div>
-              <div className="col-2-sub-header">Confirmed negative result from an official testing source.</div>
-            </label>
-          </div>
-        </form>
-      </div>
+                                                          <div className="radio">
+                                                            <input
+                                                              className="radio-input"
+                                                              name="testType"
+                                                              type="radio"
+                                                              onClick={handleRadio}
+                                                              id="likely"
+                                                              value="likely"
+                                                            ></input>
+                                                            <label htmlFor="likely" className="col-2-header-container">
+                                                              <div className="col-2-header">
+                                                                Likely Positive Diagnosis
+                                                              </div>
+                                                              <div className="col-2-sub-header">
+                                                                Clincial diagnosis without a test.
+                                                              </div>
+                                                            </label>
+                                                          </div>
 
-      <div className="row" id="onset-date-form">
-        <div className="col-1">
-          <div className="sect-header">Symptom Onset Date</div>
-          <p>The date must be within the past 14 days</p>
-        </div>
-        <div className="col-2">
-          <form id="date-form">
-            <input
-              id="date-picker"
-              className="no-value"
-              type="date"
-              min={getFourteenDaysAgoString()}
-              max={getTodayString()}
-              onChange={handleDate}
-              placeholder="mm-dd-yyyy"
-            ></input>
-          </form>
-          <p className="date-desc">Time zone set to {getDefaultTimezoneString()}</p>
-        </div>
-      </div>
+                                                          <div className="radio">
+                                                            <input
+                                                              className="radio-input"
+                                                              name="testType"
+                                                              type="radio"
+                                                              onClick={handleRadio}
+                                                              id="negative"
+                                                              value="negative"
+                                                            ></input>
+                                                            <label
+                                                              htmlFor="negative"
+                                                              className="col-2-header-container"
+                                                            >
+                                                              <div className="col-2-header">
+                                                                Confirmed Negative Test
+                                                              </div>
+                                                              <div className="col-2-sub-header">
+                                                                Confirmed negative result from an official testing
+                                                                source.
+                                                              </div>
+                                                            </label>
+                                                          </div>
+                                                        </form>
+                                                      </div>
 
-      <div className="row" id="code-form">
-        <div className="col-1">
-          <div className="sect-header">Diagnosis Verification Code</div>
-          <p>
-            Ask the patient to enter this code in the Covid Watch mobile app so that they can anonymously share a
-            verified positive diagnosis with others who were nearby when they were possibly contagious.
-          </p>
-        </div>
-        <div className="col-2">
-          <PendingOperationButton disabled={buttonDisabled} className="save-button" operation={genNewCode}>
-            Generate Code
-          </PendingOperationButton>
-          <div id="code-box" className="no-value">
-            {code}
-          </div>
+                                                      <div className="row" id="onset-date-form">
+                                                        <div className="col-1">
+                                                          <div className="sect-header">Symptom Onset Date</div>
+                                                          <p>The date must be within the past 14 days</p>
+                                                        </div>
+                                                        <div className="col-2">
+                                                          <form id="date-form">
+                                                            <input
+                                                              id="date-picker"
+                                                              className="no-value"
+                                                              type="date"
+                                                              min={getFourteenDaysAgoString()}
+                                                              max={getTodayString()}
+                                                              onChange={handleDate}
+                                                              placeholder="mm-dd-yyyy"
+                                                            ></input>
+                                                          </form>
+                                                          <p className="date-desc">
+                                                            Time zone set to {getDefaultTimezoneString()}
+                                                          </p>
+                                                        </div>
+                                                      </div>
 
-          {needsReset && (
-            <div>
-              <div id="share-urgently">
-                <img src={Clock}></img>
-                <div>Share the code ASAP. &nbsp;</div>
-                {timeLeft > 0 ? (
-                  <span>
-                    It will expire in {timeLeft} min at {expirationTime}
-                  </span>
-                ) : (
-                  <span>Code expired after 60 minutes - generate new code.</span>
-                )}
-              </div>
+                                                      {/* does this render a calendar picker upon clicking?  or a bunch of numbers vertically? */}
+                                                      <div>
+                                                        <p>TESTING NEW DATEPICKER</p>
+                                                        {datePicker}
+                                                      </div>
 
-              <PendingOperationButton operation={resetState} className="save-button">
-                Reset Code and Form
-              </PendingOperationButton>
-            </div>
-          )}
-        </div>
-      </div>
-      <Toast ref={confirmedToast} isSuccess={toastInfo.success} message={toastInfo.msg} />
-    </div>
-  )
-})
+                                                      <div className="row" id="code-form">
+                                                        <div className="col-1">
+                                                          <div className="sect-header">Diagnosis Verification Code</div>
+                                                          <p>
+                                                            Ask the patient to enter this code in the Covid Watch mobile
+                                                            app so that they can anonymously share a verified positive
+                                                            diagnosis with others who were nearby when they were
+                                                            possibly contagious.
+                                                          </p>
+                                                        </div>
+                                                        <div className="col-2">
+                                                          <PendingOperationButton
+                                                            disabled={buttonDisabled}
+                                                            className="save-button"
+                                                            operation={genNewCode}
+                                                          >
+                                                            Generate Code
+                                                          </PendingOperationButton>
+                                                          <div id="code-box" className="no-value">
+                                                            {code}
+                                                          </div>
+
+                                                          {needsReset && (
+                                                            <div>
+                                                              <div id="share-urgently">
+                                                                <img src={Clock}></img>
+                                                                <div>Share the code ASAP. &nbsp;</div>
+                                                                {timeLeft > 0 ? (
+                                                                  <span>
+                                                                    It will expire in {timeLeft} min at {expirationTime}
+                                                                  </span>
+                                                                ) : (
+                                                                  <span>
+                                                                    Code expired after 60 minutes - generate new code.
+                                                                  </span>
+                                                                )}
+                                                              </div>
+
+                                                              <PendingOperationButton
+                                                                operation={resetState}
+                                                                className="save-button"
+                                                              >
+                                                                Reset Code and Form
+                                                              </PendingOperationButton>
+                                                            </div>
+                                                          )}
+                                                        </div>
+                                                      </div>
+                                                      <Toast
+                                                        ref={confirmedToast}
+                                                        isSuccess={toastInfo.success}
+                                                        message={toastInfo.msg}
+                                                      />
+                                                    </div>
+                                                  )
+                                                })
 
 const CodeValidations = withStore(CodeValidationsBase)
 

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -23,7 +23,7 @@ const codePlaceholder = '00000000'
 
 const CodeValidationsBase = observer((props) => {
   const [testType, setTestType] = useState('')
-  const [symptomDate, setSymptomDate] = useState('')
+  const [symptomDateYYYYMMDD, setSymptomDateYYYYMMDD] = useState('')
   const [symptomDateObject, setSymptomDateObject] = useState()
   const [dateInvalid, setDateInvalid] = useState(false)
   const [needsReset, setNeedsReset] = useState(false)
@@ -64,7 +64,7 @@ const CodeValidationsBase = observer((props) => {
     try {
       let code = await props.store.getVerificationCode({
         testType: testType,
-        symptomDate: symptomDate === '' ? symptomDate : localStringToZeroUTCOffsetString(symptomDate),
+        symptomDate: symptomDateYYYYMMDD === '' ? symptomDateYYYYMMDD : localStringToZeroUTCOffsetString(symptomDateYYYYMMDD),
       })
       setCode(code.data.split('').join(''))
       codeTimeStamp()
@@ -108,21 +108,19 @@ const CodeValidationsBase = observer((props) => {
       confirmedToast.current.show()
     } else {
       setDateInvalid(false)
-      setSymptomDate(selectedDate)
+      setSymptomDateYYYYMMDD(selectedDate)
     }
     updateButtonDisabled()
   }
 
   const resetState = () => {
     document.getElementById('radio-form').reset()
-    document.getElementById('date-form').reset()
-    document.getElementById('date-picker').classList.remove('with-value')
-    document.getElementById('date-picker').classList.add('no-value')
     document.getElementById('code-box').classList.toggle('with-value')
     document.getElementById('code-box').classList.toggle('no-value')
     document.getElementById('code-box').classList.toggle('code-generated')
     setCode(codePlaceholder)
-    setSymptomDate('')
+    setSymptomDateYYYYMMDD('')
+    setSymptomDateObject('')
     setTestType('')
     setTimeLeft(60)
     setNeedsReset(false)
@@ -141,11 +139,12 @@ const CodeValidationsBase = observer((props) => {
   let datePicker = (
     <DatePicker
       id="date-picker"
-      className={symptomDate ? 'with-value' : 'no-value'}
+      className={symptomDateYYYYMMDD ? 'with-value' : 'no-value'}
       selected={symptomDateObject}
       minDate={getFourteenDaysAgoDate()}
       maxDate={new Date()}
       onChange={(date) => handleDate(date)}
+      placeholderText="Choose a date in last 14 days"
     />
   )
 
@@ -210,11 +209,6 @@ const CodeValidationsBase = observer((props) => {
         </form>
       </div>
 
-      <div>
-        Symptom Date
-        {symptomDate}
-      </div>
-
       <div className="row" id="onset-date-form">
         <div className="col-1">
           <div className="sect-header">Symptom Onset Date</div>
@@ -222,18 +216,6 @@ const CodeValidationsBase = observer((props) => {
         </div>
         <div className="col-2">
           {datePicker}
-
-          {/* <form id="date-form">
-            <input
-              id="date-picker"
-              className="no-value"
-              type="date"
-              min={getFourteenDaysAgoString()}
-              max={getTodayString()}
-              onChange={handleDate}
-              placeholder="mm-dd-yyyy"
-            ></input>
-          </form> */}
           <p className="date-desc">Time zone set to {getDefaultTimezoneString()}</p>
         </div>
       </div>

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -84,14 +84,17 @@ const CodeValidationsBase = observer((props) => {
     updateButtonDisabled()
   }
 
-  const handleDate = (date) => {
-    setSymptomDateObject(date)
-    const selectedDate = toDashSeperatedYYYYMMDDString(date)
-    document.getElementById('date-picker').classList.add('with-value')
-    document.getElementById('date-picker').classList.remove('no-value')
-    setDateInvalid(false)
-    setSymptomDateYYYYMMDD(selectedDate)
-    updateButtonDisabled()
+  const handleDate = (date) => {    
+    if(date) {
+      setSymptomDateObject(date)
+      const selectedDate = toDashSeperatedYYYYMMDDString(date)
+      setDateInvalid(false)
+      setSymptomDateYYYYMMDD(selectedDate)
+      updateButtonDisabled()
+    } else {
+      setSymptomDateObject(undefined)
+      setSymptomDateYYYYMMDD(null)
+    }
   }
 
   const resetState = () => {

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -21,312 +21,252 @@ import {
 const codePlaceholder = '00000000'
 
 const CodeValidationsBase = observer((props) => {
-                                                  const [testType, setTestType] = useState('')
-                                                  const [symptomDate, setSymptomDate] = useState('')
-                                                  const [dateInvalid, setDateInvalid] = useState(false)
-                                                  const [needsReset, setNeedsReset] = useState(false)
-                                                  const [code, setCode] = useState(codePlaceholder)
-                                                  const [buttonDisabled, setButtonDisabled] = useState(true)
-                                                  const [expirationTime, setExpirationTime] = useState('')
-                                                  const [timeLeft, setTimeLeft] = useState(60)
-                                                  const [startDate, setStartDate] = useState(new Date())
-                                                  const [toastInfo, setToastInfo] = useState({
-                                                    success: false,
-                                                    msg: '',
-                                                  })
+  const [testType, setTestType] = useState('')
+  const [symptomDate, setSymptomDate] = useState('')
+  const [dateInvalid, setDateInvalid] = useState(false)
+  const [needsReset, setNeedsReset] = useState(false)
+  const [code, setCode] = useState(codePlaceholder)
+  const [buttonDisabled, setButtonDisabled] = useState(true)
+  const [expirationTime, setExpirationTime] = useState('')
+  const [timeLeft, setTimeLeft] = useState(60)
+  const [startDate, setStartDate] = useState(new Date())
+  const [toastInfo, setToastInfo] = useState({
+    success: false,
+    msg: '',
+  })
 
-                                                  let confirmedToast = React.createRef()
+  let confirmedToast = React.createRef()
 
-                                                  useEffect(() => {
-                                                    updateButtonDisabled()
-                                                  })
+  useEffect(() => {
+    updateButtonDisabled()
+  })
 
-                                                  // Updates the buttonDisabled variable state based on other state variables
-                                                  const updateButtonDisabled = () => {
-                                                    if (needsReset || testType === '' || dateInvalid) {
-                                                      setButtonDisabled(true)
-                                                    } else {
-                                                      setButtonDisabled(false)
-                                                    }
-                                                  }
+  // Updates the buttonDisabled variable state based on other state variables
+  const updateButtonDisabled = () => {
+    if (needsReset || testType === '' || dateInvalid) {
+      setButtonDisabled(true)
+    } else {
+      setButtonDisabled(false)
+    }
+  }
 
-                                                  const countdown = (num = 60) => {
-                                                    setTimeout(() => {
-                                                      if (
-                                                        num > 0 &&
-                                                        document
-                                                          .getElementById('code-box')
-                                                          .classList.contains('code-generated')
-                                                      ) {
-                                                        setTimeLeft(num - 1)
-                                                        countdown(num - 1)
-                                                      }
-                                                    }, 60000)
-                                                  }
+  const countdown = (num = 60) => {
+    setTimeout(() => {
+      if (num > 0 && document.getElementById('code-box').classList.contains('code-generated')) {
+        setTimeLeft(num - 1)
+        countdown(num - 1)
+      }
+    }, 60000)
+  }
 
-                                                  const genNewCode = async () => {
-                                                    try {
-                                                      let code = await props.store.getVerificationCode({
-                                                        testType: testType,
-                                                        symptomDate:
-                                                          symptomDate === ''
-                                                            ? symptomDate
-                                                            : localStringToZeroUTCOffsetString(symptomDate),
-                                                      })
-                                                      setCode(code.data.split('').join(''))
-                                                      codeTimeStamp()
-                                                      setNeedsReset(true)
-                                                      updateButtonDisabled()
-                                                      countdown()
-                                                    } catch (err) {
-                                                      setToastInfo({
-                                                        success: false,
-                                                        msg: 'Could not generate new code, please try again',
-                                                      })
-                                                      confirmedToast.current.show()
-                                                    }
-                                                  }
+  const genNewCode = async () => {
+    try {
+      let code = await props.store.getVerificationCode({
+        testType: testType,
+        symptomDate: symptomDate === '' ? symptomDate : localStringToZeroUTCOffsetString(symptomDate),
+      })
+      setCode(code.data.split('').join(''))
+      codeTimeStamp()
+      setNeedsReset(true)
+      updateButtonDisabled()
+      countdown()
+    } catch (err) {
+      setToastInfo({
+        success: false,
+        msg: 'Could not generate new code, please try again',
+      })
+      confirmedToast.current.show()
+    }
+  }
 
-                                                  const handleRadio = (e) => {
-                                                    setTestType(e.target.value)
-                                                    updateButtonDisabled()
-                                                  }
+  const handleRadio = (e) => {
+    setTestType(e.target.value)
+    updateButtonDisabled()
+  }
 
-                                                  const handleDate = (e) => {
-                                                    e.target.classList.add('with-value')
-                                                    e.target.classList.remove('no-value')
+  const handleDate = (e) => {
+    e.target.classList.add('with-value')
+    e.target.classList.remove('no-value')
 
-                                                    // does not allow symptomDate in state to be set if date selected is more than 14 days ago or in the future
-                                                    if (moreThanFourteenDaysAgo(e.target.value)) {
-                                                      setDateInvalid(true)
-                                                      setToastInfo({
-                                                        success: false,
-                                                        msg: 'Date cannot be more than 14 days ago',
-                                                      })
-                                                      confirmedToast.current.show()
-                                                    } else if (dateInFuture(e.target.value)) {
-                                                      setDateInvalid(true)
-                                                      setToastInfo({
-                                                        success: false,
-                                                        msg: 'Date cannot be in the future',
-                                                      })
-                                                      confirmedToast.current.show()
-                                                    } else {
-                                                      setDateInvalid(false)
-                                                      setSymptomDate(e.target.value)
-                                                    }
-                                                    updateButtonDisabled()
-                                                  }
+    // does not allow symptomDate in state to be set if date selected is more than 14 days ago or in the future
+    if (moreThanFourteenDaysAgo(e.target.value)) {
+      setDateInvalid(true)
+      setToastInfo({
+        success: false,
+        msg: 'Date cannot be more than 14 days ago',
+      })
+      confirmedToast.current.show()
+    } else if (dateInFuture(e.target.value)) {
+      setDateInvalid(true)
+      setToastInfo({
+        success: false,
+        msg: 'Date cannot be in the future',
+      })
+      confirmedToast.current.show()
+    } else {
+      setDateInvalid(false)
+      setSymptomDate(e.target.value)
+    }
+    updateButtonDisabled()
+  }
 
-                                                  const resetState = () => {
-                                                    document.getElementById('radio-form').reset()
-                                                    document.getElementById('date-form').reset()
-                                                    document
-                                                      .getElementById('date-picker')
-                                                      .classList.remove('with-value')
-                                                    document.getElementById('date-picker').classList.add('no-value')
-                                                    document.getElementById('code-box').classList.toggle('with-value')
-                                                    document.getElementById('code-box').classList.toggle('no-value')
-                                                    document
-                                                      .getElementById('code-box')
-                                                      .classList.toggle('code-generated')
-                                                    setCode(codePlaceholder)
-                                                    setSymptomDate('')
-                                                    setTestType('')
-                                                    setTimeLeft(60)
-                                                    setNeedsReset(false)
-                                                    setDateInvalid(false)
-                                                    updateButtonDisabled()
-                                                  }
+  const resetState = () => {
+    document.getElementById('radio-form').reset()
+    document.getElementById('date-form').reset()
+    document.getElementById('date-picker').classList.remove('with-value')
+    document.getElementById('date-picker').classList.add('no-value')
+    document.getElementById('code-box').classList.toggle('with-value')
+    document.getElementById('code-box').classList.toggle('no-value')
+    document.getElementById('code-box').classList.toggle('code-generated')
+    setCode(codePlaceholder)
+    setSymptomDate('')
+    setTestType('')
+    setTimeLeft(60)
+    setNeedsReset(false)
+    setDateInvalid(false)
+    updateButtonDisabled()
+  }
 
-                                                  const codeTimeStamp = () => {
-                                                    // since this is nearly the same moment that a code is generated, we also make the code text black (this assumes the API call will never fail)
-                                                    document.getElementById('code-box').classList.toggle('with-value')
-                                                    document.getElementById('code-box').classList.toggle('no-value')
-                                                    document
-                                                      .getElementById('code-box')
-                                                      .classList.toggle('code-generated')
-                                                    setExpirationTime(getOneHourAheadDisplayString())
-                                                  }
+  const codeTimeStamp = () => {
+    // since this is nearly the same moment that a code is generated, we also make the code text black (this assumes the API call will never fail)
+    document.getElementById('code-box').classList.toggle('with-value')
+    document.getElementById('code-box').classList.toggle('no-value')
+    document.getElementById('code-box').classList.toggle('code-generated')
+    setExpirationTime(getOneHourAheadDisplayString())
+  }
 
-                                                  // simply using basic example from ReactDatePicker docs for now: https://reactdatepicker.com/
-                                                  let datePicker = (
-                                                    <DatePicker
-                                                      selected={startDate}
-                                                      onChange={(date) => setStartDate(date)}
-                                                    />
-                                                  )
+  // simply using basic example from ReactDatePicker docs for now: https://reactdatepicker.com/
+  let datePicker = <DatePicker selected={startDate} onChange={(date) => setStartDate(date)} />
 
-                                                  return !props.store.data.user.isSignedIn ||
-                                                    props.store.data.user.isFirstTimeUser ||
-                                                    (props.store.data.user.passwordResetRequested &&
-                                                      props.store.data.user.signedInWithEmailLink) ? (
-                                                    <Redirect to={ROUTES.LANDING} />
-                                                  ) : (
-                                                    <div className="module-container" id="diagnosis-codes">
-                                                      <PageTitle title="Diagnosis Verification Codes" />
-                                                      <h1>Diagnosis Verification Codes</h1>
-                                                      <h2>
-                                                        Submit this form when you are prepared to generate and
-                                                        immediately share the code with a patient.
-                                                      </h2>
-                                                      <div className="row" id="test-type-form">
-                                                        <div className="col-1">
-                                                          <div className="sect-header">COVID-19 Diagnosis</div>
-                                                        </div>
-                                                        <form id="radio-form" className="col-2">
-                                                          <div className="radio">
-                                                            <input
-                                                              className="radio-input"
-                                                              name="testType"
-                                                              type="radio"
-                                                              onClick={handleRadio}
-                                                              id="confirmed"
-                                                              value="confirmed"
-                                                            ></input>
-                                                            <label
-                                                              htmlFor="confirmed"
-                                                              className="col-2-header-container"
-                                                            >
-                                                              <div className="col-2-header">
-                                                                Confirmed Positive Test
-                                                              </div>
-                                                              <div className="col-2-sub-header">
-                                                                Confirmed positive result from an official testing
-                                                                source.
-                                                              </div>
-                                                            </label>
-                                                          </div>
+  return !props.store.data.user.isSignedIn ||
+    props.store.data.user.isFirstTimeUser ||
+    (props.store.data.user.passwordResetRequested && props.store.data.user.signedInWithEmailLink) ? (
+    <Redirect to={ROUTES.LANDING} />
+  ) : (
+    <div className="module-container" id="diagnosis-codes">
+      <PageTitle title="Diagnosis Verification Codes" />
+      <h1>Diagnosis Verification Codes</h1>
+      <h2>Submit this form when you are prepared to generate and immediately share the code with a patient.</h2>
+      <div className="row" id="test-type-form">
+        <div className="col-1">
+          <div className="sect-header">COVID-19 Diagnosis</div>
+        </div>
+        <form id="radio-form" className="col-2">
+          <div className="radio">
+            <input
+              className="radio-input"
+              name="testType"
+              type="radio"
+              onClick={handleRadio}
+              id="confirmed"
+              value="confirmed"
+            ></input>
+            <label htmlFor="confirmed" className="col-2-header-container">
+              <div className="col-2-header">Confirmed Positive Test</div>
+              <div className="col-2-sub-header">Confirmed positive result from an official testing source.</div>
+            </label>
+          </div>
 
-                                                          <div className="radio">
-                                                            <input
-                                                              className="radio-input"
-                                                              name="testType"
-                                                              type="radio"
-                                                              onClick={handleRadio}
-                                                              id="likely"
-                                                              value="likely"
-                                                            ></input>
-                                                            <label htmlFor="likely" className="col-2-header-container">
-                                                              <div className="col-2-header">
-                                                                Likely Positive Diagnosis
-                                                              </div>
-                                                              <div className="col-2-sub-header">
-                                                                Clincial diagnosis without a test.
-                                                              </div>
-                                                            </label>
-                                                          </div>
+          <div className="radio">
+            <input
+              className="radio-input"
+              name="testType"
+              type="radio"
+              onClick={handleRadio}
+              id="likely"
+              value="likely"
+            ></input>
+            <label htmlFor="likely" className="col-2-header-container">
+              <div className="col-2-header">Likely Positive Diagnosis</div>
+              <div className="col-2-sub-header">Clincial diagnosis without a test.</div>
+            </label>
+          </div>
 
-                                                          <div className="radio">
-                                                            <input
-                                                              className="radio-input"
-                                                              name="testType"
-                                                              type="radio"
-                                                              onClick={handleRadio}
-                                                              id="negative"
-                                                              value="negative"
-                                                            ></input>
-                                                            <label
-                                                              htmlFor="negative"
-                                                              className="col-2-header-container"
-                                                            >
-                                                              <div className="col-2-header">
-                                                                Confirmed Negative Test
-                                                              </div>
-                                                              <div className="col-2-sub-header">
-                                                                Confirmed negative result from an official testing
-                                                                source.
-                                                              </div>
-                                                            </label>
-                                                          </div>
-                                                        </form>
-                                                      </div>
+          <div className="radio">
+            <input
+              className="radio-input"
+              name="testType"
+              type="radio"
+              onClick={handleRadio}
+              id="negative"
+              value="negative"
+            ></input>
+            <label htmlFor="negative" className="col-2-header-container">
+              <div className="col-2-header">Confirmed Negative Test</div>
+              <div className="col-2-sub-header">Confirmed negative result from an official testing source.</div>
+            </label>
+          </div>
+        </form>
+      </div>
 
-                                                      <div className="row" id="onset-date-form">
-                                                        <div className="col-1">
-                                                          <div className="sect-header">Symptom Onset Date</div>
-                                                          <p>The date must be within the past 14 days</p>
-                                                        </div>
-                                                        <div className="col-2">
-                                                          <form id="date-form">
-                                                            <input
-                                                              id="date-picker"
-                                                              className="no-value"
-                                                              type="date"
-                                                              min={getFourteenDaysAgoString()}
-                                                              max={getTodayString()}
-                                                              onChange={handleDate}
-                                                              placeholder="mm-dd-yyyy"
-                                                            ></input>
-                                                          </form>
-                                                          <p className="date-desc">
-                                                            Time zone set to {getDefaultTimezoneString()}
-                                                          </p>
-                                                        </div>
-                                                      </div>
+      <div className="row" id="onset-date-form">
+        <div className="col-1">
+          <div className="sect-header">Symptom Onset Date</div>
+          <p>The date must be within the past 14 days</p>
+        </div>
+        <div className="col-2">
+          <form id="date-form">
+            <input
+              id="date-picker"
+              className="no-value"
+              type="date"
+              min={getFourteenDaysAgoString()}
+              max={getTodayString()}
+              onChange={handleDate}
+              placeholder="mm-dd-yyyy"
+            ></input>
+          </form>
+          <p className="date-desc">Time zone set to {getDefaultTimezoneString()}</p>
+        </div>
+      </div>
 
-                                                      {/* does this render a calendar picker upon clicking?  or a bunch of numbers vertically? */}
-                                                      <div>
-                                                        <p>TESTING NEW DATEPICKER</p>
-                                                        {datePicker}
-                                                      </div>
+      {/* does this render a calendar picker upon clicking?  or a bunch of numbers vertically? */}
+      <div>
+        <p>TESTING NEW DATEPICKER</p>
+        {datePicker}
+      </div>
 
-                                                      <div className="row" id="code-form">
-                                                        <div className="col-1">
-                                                          <div className="sect-header">Diagnosis Verification Code</div>
-                                                          <p>
-                                                            Ask the patient to enter this code in the Covid Watch mobile
-                                                            app so that they can anonymously share a verified positive
-                                                            diagnosis with others who were nearby when they were
-                                                            possibly contagious.
-                                                          </p>
-                                                        </div>
-                                                        <div className="col-2">
-                                                          <PendingOperationButton
-                                                            disabled={buttonDisabled}
-                                                            className="save-button"
-                                                            operation={genNewCode}
-                                                          >
-                                                            Generate Code
-                                                          </PendingOperationButton>
-                                                          <div id="code-box" className="no-value">
-                                                            {code}
-                                                          </div>
+      <div className="row" id="code-form">
+        <div className="col-1">
+          <div className="sect-header">Diagnosis Verification Code</div>
+          <p>
+            Ask the patient to enter this code in the Covid Watch mobile app so that they can anonymously share a
+            verified positive diagnosis with others who were nearby when they were possibly contagious.
+          </p>
+        </div>
+        <div className="col-2">
+          <PendingOperationButton disabled={buttonDisabled} className="save-button" operation={genNewCode}>
+            Generate Code
+          </PendingOperationButton>
+          <div id="code-box" className="no-value">
+            {code}
+          </div>
 
-                                                          {needsReset && (
-                                                            <div>
-                                                              <div id="share-urgently">
-                                                                <img src={Clock}></img>
-                                                                <div>Share the code ASAP. &nbsp;</div>
-                                                                {timeLeft > 0 ? (
-                                                                  <span>
-                                                                    It will expire in {timeLeft} min at {expirationTime}
-                                                                  </span>
-                                                                ) : (
-                                                                  <span>
-                                                                    Code expired after 60 minutes - generate new code.
-                                                                  </span>
-                                                                )}
-                                                              </div>
+          {needsReset && (
+            <div>
+              <div id="share-urgently">
+                <img src={Clock}></img>
+                <div>Share the code ASAP. &nbsp;</div>
+                {timeLeft > 0 ? (
+                  <span>
+                    It will expire in {timeLeft} min at {expirationTime}
+                  </span>
+                ) : (
+                  <span>Code expired after 60 minutes - generate new code.</span>
+                )}
+              </div>
 
-                                                              <PendingOperationButton
-                                                                operation={resetState}
-                                                                className="save-button"
-                                                              >
-                                                                Reset Code and Form
-                                                              </PendingOperationButton>
-                                                            </div>
-                                                          )}
-                                                        </div>
-                                                      </div>
-                                                      <Toast
-                                                        ref={confirmedToast}
-                                                        isSuccess={toastInfo.success}
-                                                        message={toastInfo.msg}
-                                                      />
-                                                    </div>
-                                                  )
-                                                })
+              <PendingOperationButton operation={resetState} className="save-button">
+                Reset Code and Form
+              </PendingOperationButton>
+            </div>
+          )}
+        </div>
+      </div>
+      <Toast ref={confirmedToast} isSuccess={toastInfo.success} message={toastInfo.msg} />
+    </div>
+  )
+})
 
 const CodeValidations = withStore(CodeValidationsBase)
 

--- a/frontend/client/src/util/time.js
+++ b/frontend/client/src/util/time.js
@@ -46,6 +46,15 @@ export const getFourteenDaysAgoString = () => {
   return toDashSeperatedYYYYMMDDString(ourDate)
 }
 
+export const getFourteenDaysAgoDate = () => {
+  var ourDate = new Date()
+
+  //Change date picker minimum to be 14 days in the past.
+  var pastDate = ourDate.getDate() - 13
+  ourDate.setDate(pastDate)
+  return ourDate
+}
+
 // gets today's date as a string formatted as yyyy-mm-dd
 export const getTodayString = () => {
   return toDashSeperatedYYYYMMDDString(new Date())

--- a/frontend/client/src/util/time.js
+++ b/frontend/client/src/util/time.js
@@ -60,23 +60,6 @@ export const getTodayString = () => {
   return toDashSeperatedYYYYMMDDString(new Date())
 }
 
-// is this date more than 14 days ago?
-export const moreThanFourteenDaysAgo = (strChosenDate) => {
-  let chosenDate = new Date(strChosenDate)
-  // adding + 1 to the chosenDate is necessary bc the way new Date() takes in a string seems to move it one date less on the returned Date
-  chosenDate.setDate(chosenDate.getDate() + 1)
-  let now = new Date()
-  now.setDate(now.getDate() - 14)
-  return chosenDate < now
-}
-
-// is this date in the future?
-export const dateInFuture = (strChosenDate) => {
-  let chosenDate = new Date(strChosenDate)
-  let today = new Date()
-  return chosenDate > today
-}
-
 // Converts a local yyyy-mm-dd date string to zero UTC offset yyyy-mm-dd date string
 export const localStringToZeroUTCOffsetString = (localDateString) => {
   const localDate = new Date(localDateString)

--- a/frontend/client/styles/screens/code_validations.scss
+++ b/frontend/client/styles/screens/code_validations.scss
@@ -1,6 +1,8 @@
 @import '../color.scss';
 @import '../include-media';
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;800&display=swap');
+@import 'react-datepicker/dist/react-datepicker';
+
 
 #diagnosis-codes {
   h2 {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6553,6 +6553,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -7380,6 +7385,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-context": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "cross-env": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz",
@@ -7569,8 +7583,7 @@
     "date-fns": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.15.0.tgz",
-      "integrity": "sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==",
-      "dev": true
+      "integrity": "sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -7631,7 +7644,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -7679,7 +7691,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -8294,7 +8305,6 @@
       "version": "1.17.5",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
       "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -8313,7 +8323,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -9432,8 +9441,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
       "version": "1.1.2",
@@ -9715,6 +9723,11 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -9746,7 +9759,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -9794,8 +9806,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -10463,8 +10474,7 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -10494,8 +10504,7 @@
     "is-callable": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-      "dev": true
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -10527,8 +10536,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -10707,7 +10715,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -10748,7 +10755,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -15561,14 +15567,12 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -15577,8 +15581,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -15592,7 +15595,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -16940,6 +16942,18 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-datepicker": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-3.1.3.tgz",
+      "integrity": "sha512-4KbdWWAxa/AZJIDhQZwiBpZE9hCYZ4/gTVstdo9WEpFCsfh69xHklB/FZrR95mgkIU7ecU36V2eCuGgIO+ci0A==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "date-fns": "^2.0.1",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.9.0",
+        "react-popper": "^1.3.4"
+      }
+    },
     "react-document-title": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/react-document-title/-/react-document-title-2.0.3.tgz",
@@ -16991,6 +17005,25 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-onclickoutside": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz",
+      "integrity": "sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A=="
+    },
+    "react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "^0.3.0",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      }
     },
     "react-redux": {
       "version": "7.2.0",
@@ -17263,7 +17296,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -18538,7 +18570,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -18548,7 +18579,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
       "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
@@ -18559,7 +18589,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
       "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
@@ -18570,7 +18599,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -19169,6 +19197,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -19744,6 +19777,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "mobx-react": "^6.2.2",
     "mobx-state-tree": "^3.16.0",
     "react": "^16.13.1",
+    "react-datepicker": "^3.1.3",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.13.1",
     "react-hot-loader": "^4.12.20",


### PR DESCRIPTION
closes #491 #410 

Safari desktop [doesn't support a calendar picker](https://stackoverflow.com/questions/35682138/html5-date-picker-doesnt-show-on-safari) unfortunately (lame).

More robust solution is to populate a calendar picker no matter the browser, which is done here using [ReactDatePicker](https://reactdatepicker.com/).  I tested the whole workflow on Safari and all works as expected (same as Chrome).

Note that Safari mobile has a much better date picker UX.  I was concerned about this as it seems many users will be on mobile and Safari is the default browser for iPhones.  No need to adjust for this, thankfully (see screenshot below from my own iPhone on Safari):

![IMG_A7E7458123B1-1](https://user-images.githubusercontent.com/16062590/90190628-61410600-dd8d-11ea-9a11-3c81db801de2.jpeg)
