### PR TITLE
Date Picker Bug

### DIFF
--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -100,6 +100,7 @@ const CodeValidationsBase = observer((props) => {
   }
 
   const resetState = () => {
+    document.getElementById('date-picker').value = ''
     document.getElementById('radio-form').reset()
     document.getElementById('date-form').reset()
     document.getElementById('date-picker').classList.remove('with-value')

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -118,7 +118,7 @@ const SignInFormBase = observer(
             <label className="small-text" htmlFor="email">
               Email Address
             </label>
-            <input onChange={this.onChange('email')} type="email" id="email" name="email" ref={this.emailInput}/>
+            <input onChange={this.onChange('email')} type="email" id="email" name="email" ref={this.emailInput} />
             <label className="small-text" htmlFor="password">
               Password
             </label>


### PR DESCRIPTION
Closes #435 

The bug here occurs only when  the same date is selected for 2 tests in a row. In `resetState()`  we set call `reset()` on the date picker form. Calling `reset()` clears the date input box, but does not actually reset the `value` stored in the input element. So, the second time the date is selected, it is not registered a change in the input element. Here, we log the value of `symptomDate` in `genNewCode()`. 


![Screen Capture_Navigator_20200813232848](https://user-images.githubusercontent.com/20446774/90220541-3ec6e100-ddbd-11ea-88d9-a7106a4f2cd4.gif)


The easy fix is to set `value={symptomDate}` in the props of the `<input>` tag. This ensures the value in the input component is always `symptomDate`, which is set to an empty string when the reset button is pressed. However, this caused weird behavior when typing in new dates.

So, instead we manually reset the value of the input component to an empty string in `resetState()`. This seems to fix the issue. 
![Screen Capture_Navigator_20200813233415](https://user-images.githubusercontent.com/20446774/90220698-8e0d1180-ddbd-11ea-8270-f690641d21cc.gif)
