### PR TITLE
Update VS urls

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,6 @@ jobs:
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           NODE_ENV: test
           VERIFICATION_SERVER_API_KEY: ${{ secrets.VERIFICATION_SERVER_API_KEY }}
-          VERIFICATION_SERVER_URL: ${{ secrets.VERIFICATION_SERVER_URL }}
       - name: Lint and Build
         working-directory: cloud-functions/functions
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,6 @@ jobs:
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           NODE_ENV: staging
           VERIFICATION_SERVER_API_KEY: ${{ secrets.VERIFICATION_SERVER_API_KEY }}
-          VERIFICATION_SERVER_URL: ${{ secrets.VERIFICATION_SERVER_URL }}
       - name: Setup functions config
         if: github.ref == 'refs/heads/dev'
         working-directory: cloud-functions/functions
@@ -85,7 +84,6 @@ jobs:
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           NODE_ENV: dev
           VERIFICATION_SERVER_API_KEY: ${{ secrets.VERIFICATION_SERVER_API_KEY }}
-          VERIFICATION_SERVER_URL: ${{ secrets.VERIFICATION_SERVER_URL }}
       - name: Setup functions config
         if: github.ref == 'refs/heads/master'
         working-directory: cloud-functions/functions
@@ -95,7 +93,6 @@ jobs:
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           NODE_ENV: prod
           VERIFICATION_SERVER_API_KEY: ${{ secrets.VERIFICATION_SERVER_API_KEY }}
-          VERIFICATION_SERVER_URL: ${{ secrets.VERIFICATION_SERVER_URL }}
 
       - name: Lint and Build
         working-directory: cloud-functions/functions

--- a/config/functions.config.dev.js
+++ b/config/functions.config.dev.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: process.env.VERIFICATION_SERVER_URL,
+    url: "https://dev.adminapi.verification.covidwatch.org",
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.local.js
+++ b/config/functions.config.local.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: process.env.VERIFICATION_SERVER_URL,
+    url: "https://dev.adminapi.verification.covidwatch.org",
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.prod.js
+++ b/config/functions.config.prod.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: process.env.VERIFICATION_SERVER_URL,
+    url: "https://adminapi.verification.covidwatch.org",
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.staging.js
+++ b/config/functions.config.staging.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: process.env.VERIFICATION_SERVER_URL,
+    url: "https://dev.adminapi.verification.covidwatch.org",
     key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };

--- a/config/functions.config.test.js
+++ b/config/functions.config.test.js
@@ -6,7 +6,7 @@ var config = {
     key: process.env.SENDGRID_API_KEY,
   },
   verification_server: {
-    url: "**url**",
+    url: "https://dev.adminapi.verification.covidwatch.org",
     key: "**key**",
   },
 };

--- a/config/functions.config.test.js
+++ b/config/functions.config.test.js
@@ -7,7 +7,7 @@ var config = {
   },
   verification_server: {
     url: "https://dev.adminapi.verification.covidwatch.org",
-    key: "**key**",
+    key: process.env.VERIFICATION_SERVER_API_KEY,
   },
 };
 


### PR DESCRIPTION
Updating the verification server urls to distinguish between dev and prod. All infrastructures point to https://dev.adminapi.verification.covidwatch.org, except for prod which points to https://adminapi.verification.covidwatch.org.

Hardcodes the url strings rather than using environment variables, since they're not secret.

Also updates the test config to use the dev VS url and grab the API key from the env, in preparation for future integration test development.

NOTE-to-self: after this is merged would be a good time to go through our Github secrets and clean up some cruft.