### PR TITLE
My settings page overlap fix on smaller screen sizees

### DIFF
--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -186,7 +186,7 @@ const SettingsBase = observer((props) => {
     <Fragment>
       <form>
         <Grid container id="settings-grid" spacing={2} direction="row" justify="center">
-          <Grid item xs={12} md={4} xl={2}>
+          <Grid item xs={12} md={12} lg={4} xl={2}>
             <Grid container spacing={2} direction="column" className="profile-photo-container">
               <label> Profile Photo </label>
               <div
@@ -222,7 +222,7 @@ const SettingsBase = observer((props) => {
             </Grid>
           </Grid>
 
-          <Grid item xs={12} md={4} xl={5}>
+          <Grid item xs={12} md={6} lg={4} xl={5}>
             <Grid container spacing={2} direction="column">
               <label htmlFor="prefix">Prefix</label>
               <input
@@ -256,7 +256,7 @@ const SettingsBase = observer((props) => {
             </Grid>
           </Grid>
 
-          <Grid item xs={12} md={4} xl={5}>
+          <Grid item xs={12} md={6} lg={4} xl={5}>
             <Grid container spacing={2} direction="column">
               <label htmlFor="role">Role</label>
               {props.store.data.user && (

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -56,7 +56,7 @@ const SettingsBase = observer((props) => {
           msg: 'First name must be at least one character',
         })
         toastRef.current.show()
-      } else  {
+      } else {
         props.store.updateUser({ firstName: event.target.value })
       }
     } else if (event.target.name == 'lastName') {

--- a/frontend/client/styles/screens/settings.scss
+++ b/frontend/client/styles/screens/settings.scss
@@ -45,12 +45,14 @@
     margin-bottom: 40px;
   }
 
-  @include media('<=phone') {
-    padding: 0 8px 40px 8px;
-
+  @include media('<desktop') {
     .MuiGrid-direction-xs-column {
       align-items: center;
     }
+  }
+
+  @include media('<=phone') {
+    padding: 0 8px 40px 8px;
 
     .profile-photo-container {
       margin-bottom: 8px;


### PR DESCRIPTION
Resolves #497  
  
Breakpoint for items moving around happens a bit earlier to prevent overlap. Only adjusted material-ui grid and moved media query for items aligning center to `<desktop` instead of `<=phone`. Gif shown below:  
  
![my-settings](https://user-images.githubusercontent.com/56734437/90287657-4aaab580-de46-11ea-9cf5-d1bf6328576d.gif)
