### PR TITLE
refactor reset form workflow to always have radio value be confirmed

### DIFF
--- a/frontend/client/__tests__/code_validations.test.js
+++ b/frontend/client/__tests__/code_validations.test.js
@@ -39,11 +39,6 @@ describe('Code Validations', () => {
     CodeVWrapped = createStore(CodeValidations)
   })
 
-  it('cannote generate a code when no options are selected', () => {
-    const wrapped = mount(<CodeVWrapped />)
-    expect(wrapped.find(PendingOperationButton).at(0).props().disabled).toBe(true)
-  })
-
   it('can generate code with correct options', async () => {
     // Mock document.getElementById used by the CodeValidations component.
     // JsDOM doesn't handle this well and document.getElementById returns null in the tests without this mock
@@ -64,11 +59,6 @@ describe('Code Validations', () => {
           value: getTodayString(),
         },
       })
-    // Can't generate a code with a date, even if it's valid
-    expect(wrapped.find(PendingOperationButton).at(0).props().disabled).toBe(true)
-
-    // Click diagnosis button
-    wrapped.find('.radio-input').at(0).simulate('click')
 
     // Ensure "Generate Code" button is enabled and click it
     expect(wrapped.find(PendingOperationButton).at(0).props().disabled).toBe(false)

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -20,13 +20,13 @@ import {
 const codePlaceholder = '00000000'
 
 const CodeValidationsBase = observer((props) => {
-  const [testType, setTestType] = useState('')
+  const [testType] = useState('confirmed')
   const [symptomDateYYYYMMDD, setSymptomDateYYYYMMDD] = useState('')
   const [symptomDateObject, setSymptomDateObject] = useState()
   const [dateInvalid, setDateInvalid] = useState(false)
   const [needsReset, setNeedsReset] = useState(false)
   const [code, setCode] = useState(codePlaceholder)
-  const [buttonDisabled, setButtonDisabled] = useState(true)
+  const [buttonDisabled, setButtonDisabled] = useState(false)
   const [expirationTime, setExpirationTime] = useState('')
   const [timeLeft, setTimeLeft] = useState(60)
   const [toastInfo, setToastInfo] = useState({
@@ -42,7 +42,7 @@ const CodeValidationsBase = observer((props) => {
 
   // Updates the buttonDisabled variable state based on other state variables
   const updateButtonDisabled = () => {
-    if (needsReset || testType === '' || dateInvalid) {
+    if (needsReset || dateInvalid) {
       setButtonDisabled(true)
     } else {
       setButtonDisabled(false)
@@ -79,11 +79,6 @@ const CodeValidationsBase = observer((props) => {
     }
   }
 
-  const handleRadio = (e) => {
-    setTestType(e.target.value)
-    updateButtonDisabled()
-  }
-
   const handleDate = (date) => {
     if (date) {
       setSymptomDateObject(date)
@@ -106,7 +101,6 @@ const CodeValidationsBase = observer((props) => {
     setCode(codePlaceholder)
     setSymptomDateYYYYMMDD('')
     setSymptomDateObject('')
-    setTestType('')
     setTimeLeft(60)
     setNeedsReset(false)
     setDateInvalid(false)
@@ -149,46 +143,16 @@ const CodeValidationsBase = observer((props) => {
         <form id="radio-form" className="col-2">
           <div className="radio">
             <input
+              defaultChecked
               className="radio-input"
               name="testType"
               type="radio"
-              onClick={handleRadio}
               id="confirmed"
               value="confirmed"
             ></input>
             <label htmlFor="confirmed" className="col-2-header-container">
               <div className="col-2-header">Confirmed Positive Test</div>
               <div className="col-2-sub-header">Confirmed positive result from an official testing source.</div>
-            </label>
-          </div>
-
-          <div className="radio">
-            <input
-              className="radio-input"
-              name="testType"
-              type="radio"
-              onClick={handleRadio}
-              id="likely"
-              value="likely"
-            ></input>
-            <label htmlFor="likely" className="col-2-header-container">
-              <div className="col-2-header">Likely Positive Diagnosis</div>
-              <div className="col-2-sub-header">Clincial diagnosis without a test.</div>
-            </label>
-          </div>
-
-          <div className="radio">
-            <input
-              className="radio-input"
-              name="testType"
-              type="radio"
-              onClick={handleRadio}
-              id="negative"
-              value="negative"
-            ></input>
-            <label htmlFor="negative" className="col-2-header-container">
-              <div className="col-2-header">Confirmed Negative Test</div>
-              <div className="col-2-sub-header">Confirmed negative result from an official testing source.</div>
             </label>
           </div>
         </form>


### PR DESCRIPTION
See [this Asana task](https://app.asana.com/0/1184720811395617/1189146139134603/f).  DM me on Slack if you can't access Asana.

Copying the text from Asana just in case ppl can't access it.  This is a task created by Sameer.  Basically with this PR users can more quickly generate codes as the single action they can complete in Portal.


##From Asana:

"We only support positive diagnosis.
Having the other two options is creating user confusion.

lets hide the 2nd & 3rd options.
Make 1st one be selected by default

In October we will need to turn it back on when the app actually starts supporting it." 