### PR TITLE
resolve no code generated after deleting date

### DIFF
--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -88,7 +88,7 @@ const CodeValidationsBase = observer((props) => {
       updateButtonDisabled()
     } else {
       setSymptomDateObject(undefined)
-      setSymptomDateYYYYMMDD(null)
+      setSymptomDateYYYYMMDD('')
     }
   }
 


### PR DESCRIPTION
Resolves this [Asana task ](https://app.asana.com/0/1188301658055194/1189443161936967/f).  

`symptomDateYYYYMMDD` was being set to `null` instead of `''` (empty string), which was conflicting with the logic in function `genNewCode`.