### PR TITLE
Add password strength meter

### DIFF
--- a/frontend/client/__tests__/reset-password.test.js
+++ b/frontend/client/__tests__/reset-password.test.js
@@ -68,7 +68,7 @@ describe('reset password', () => {
     }
     wrapper
       .find('#new-password')
-      .at(1)
+      .at(2)
       .simulate('change', {
         target: {
           name: 'new-password',

--- a/frontend/client/__tests__/reset-password.test.js
+++ b/frontend/client/__tests__/reset-password.test.js
@@ -33,14 +33,14 @@ jest.mock('../src/store/firebase', () => {
 
 describe('reset password', () => {
   it.each([
-    ['Changes password succesfully (ResetPasswordModal)', ResetPasswordModal, 'password1', 'password1'],
+    ['Changes password succesfully (ResetPasswordModal)', ResetPasswordModal, 'horsebattery123', 'horsebattery123'],
     [
       'Does not change password when confirmation does not match (ResetPasswordModal)',
       ResetPasswordModal,
       'password1',
       'password2',
     ],
-    ['Changes password succesfully (ChangePasswordModal)', ChangePasswordModal, 'password1', 'password1'],
+    ['Changes password succesfully (ChangePasswordModal)', ChangePasswordModal, 'horsebattery123', 'horsebattery123'],
     [
       'Does not change password when confirmation does not match (ChangePasswordModal)',
       ChangePasswordModal,

--- a/frontend/client/src/components/ChangePasswordModal.js
+++ b/frontend/client/src/components/ChangePasswordModal.js
@@ -112,15 +112,9 @@ class ChangePasswordModalBase extends React.Component {
               label="New Password"
               id="new-password"
               required={true}
-              password={true}
               value={this.state.password}
               onChange={this.onChange}
               validation={this.state.formHasBeenEdited}
-              validationMessage={
-                this.state.password.length > 0
-                  ? 'Password must be at least 6 characters long'
-                  : 'New password cannot be blank'
-              }
             />
 
             <ModalInput

--- a/frontend/client/src/components/ChangePasswordModal.js
+++ b/frontend/client/src/components/ChangePasswordModal.js
@@ -39,7 +39,6 @@ class ChangePasswordModalBase extends React.Component {
       }
       if (fieldName === 'new-password') {
         newState.password = fieldContent
-        newState.passwordIsValid = newState.password && newState.password.length >= 6
         newState.passwordsMatch = newState.password === state.confirmPassword
       }
       if (fieldName === 'confirm-password') {
@@ -115,6 +114,9 @@ class ChangePasswordModalBase extends React.Component {
               value={this.state.password}
               onChange={this.onChange}
               validation={this.state.formHasBeenEdited}
+              notifyValidationResult={(valid) => {
+                this.setState({ passwordIsValid: valid })
+              }}
             />
 
             <ModalInput

--- a/frontend/client/src/components/ChangePasswordModal.js
+++ b/frontend/client/src/components/ChangePasswordModal.js
@@ -4,6 +4,7 @@ import ModalInput from '../components/ModalInput'
 import PendingOperationButton from '../components/PendingOperationButton'
 import { withStore } from '../store'
 import Logging from '../util/logging'
+import PasswordStrengthModalInput from './PasswordStrengthModalInput'
 
 class ChangePasswordModalBase extends React.Component {
   constructor(props) {
@@ -107,14 +108,14 @@ class ChangePasswordModalBase extends React.Component {
         <p>{this.state.subHeading}</p>
         {this.state.showNewPasswordInputs && (
           <form className="change-password-form">
-            <ModalInput
+            <PasswordStrengthModalInput
               label="New Password"
               id="new-password"
               required={true}
               password={true}
               value={this.state.password}
               onChange={this.onChange}
-              validation={!this.state.passwordIsValid && this.state.formHasBeenEdited}
+              validation={this.state.formHasBeenEdited}
               validationMessage={
                 this.state.password.length > 0
                   ? 'Password must be at least 6 characters long'

--- a/frontend/client/src/components/ModalInput.js
+++ b/frontend/client/src/components/ModalInput.js
@@ -26,7 +26,12 @@ const ModalInput = (props) => {
         value={props.value}
         onChange={props.onChange}
       />
-      <div className="validationResult">{props.validation && props.validationMessage}</div>
+      <div
+        className="validationResult"
+        style={{color: props.validationColor}}
+      >
+        {props.validation && props.validationMessage}
+      </div>
     </div>
   )
 }

--- a/frontend/client/src/components/ModalInput.js
+++ b/frontend/client/src/components/ModalInput.js
@@ -26,10 +26,7 @@ const ModalInput = (props) => {
         value={props.value}
         onChange={props.onChange}
       />
-      <div
-        className="validationResult"
-        style={{color: props.validationColor}}
-      >
+      <div className="validationResult" style={{ color: props.validationColor }}>
         {props.validation && props.validationMessage}
       </div>
     </div>

--- a/frontend/client/src/components/PasswordStrengthModalInput.js
+++ b/frontend/client/src/components/PasswordStrengthModalInput.js
@@ -1,17 +1,20 @@
-import React from 'react'
+import React, { useState } from 'react'
 import zxcvbn from 'zxcvbn'
 import ModalInput from '../components/ModalInput'
 
 /**
  * A component combining a ModalInput with a password strength meter.
- * @param {*} props.label      the label for the component
- * @param {*} props.id         the component ID
+ * @param {*} props.label                  the label for the component
+ * @param {*} props.id                     the component ID
  * @param {*} props.required
- * @param {*} props.value      the current value of the form field
- * @param {*} props.onChange   event handler
- * @param {*} props.validation whether to display a validation message
+ * @param {*} props.value                  the current value of the form field
+ * @param {*} props.validation             whether to display a validation message
+ * @param {*} props.onChange               called when the contents of the parent modal's form change
+ * @param {*} props.notifyValidationResult called to notify the parent of a validation result
  */
 const PasswordStrengthModalInput = (props) => {
+  const [validationResult, setValidationResult] = useState({})
+
   const estimatePasswordStrength = (password) => {
     let result = zxcvbn(password)
     return result.score
@@ -36,8 +39,6 @@ const PasswordStrengthModalInput = (props) => {
     }
   }
 
-  let validationResult = validation(props.value)
-
   return (
     <ModalInput
       label={props.label}
@@ -45,7 +46,12 @@ const PasswordStrengthModalInput = (props) => {
       required={props.required}
       password={true}
       value={props.value}
-      onChange={props.onChange}
+      onChange={(e) => {
+        props.onChange(e)
+        let newValidationResult = validation(props.value)
+        setValidationResult(newValidationResult)
+        props.notifyValidationResult(newValidationResult.valid)
+      }}
       validation={props.validation}
       validationMessage={validationResult.message}
       validationColor={validationResult.color}

--- a/frontend/client/src/components/PasswordStrengthModalInput.js
+++ b/frontend/client/src/components/PasswordStrengthModalInput.js
@@ -19,19 +19,19 @@ const PasswordStrengthModalInput = (props) => {
 
   const validation = (password) => {
     if (password.length < 6) {
-      return { valid: false, message: 'Password is too short' }
+      return { valid: false, message: 'Password is too short', color: '#f05452' }
     } else {
       let score = estimatePasswordStrength(password)
       switch (score) {
         case 0:
         case 1:
-          return { valid: false, message: 'Password strength: weak' }
+          return { valid: false, message: 'Password strength: weak', color: '#f05452' }
         case 2:
-          return { valid: true, message: 'Password strength: okay' }
+          return { valid: true, message: 'Password strength: okay', color: '#43c4d9' }
         case 3:
-          return { valid: true, message: 'Password strength: good' }
+          return { valid: true, message: 'Password strength: good', color: '#388ec5' }
         case 4:
-          return { valid: true, message: 'Password strength: great' }
+          return { valid: true, message: 'Password strength: great', color: '#2c58b1' }
       }
     }
   }
@@ -48,6 +48,7 @@ const PasswordStrengthModalInput = (props) => {
       onChange={props.onChange}
       validation={props.validation}
       validationMessage={validationResult.message}
+      validationColor={validationResult.color}
     />
   )
 }

--- a/frontend/client/src/components/PasswordStrengthModalInput.js
+++ b/frontend/client/src/components/PasswordStrengthModalInput.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import zxcvbn from 'zxcvbn'
+import ModalInput from '../components/ModalInput'
+
+/**
+ * 
+ * @param {*} props.label      the label for the component
+ * @param {*} props.id         the component ID
+ * @param {*} props.required
+ * @param {*} props.value      the current value of the form field
+ * @param {*} props.onChange   event handler
+ * @param {*} props.validation whether to display a validation message
+ */
+const PasswordStrengthModalInput = (props) => {
+  const estimatePasswordStrength = (password) => {
+    let result = zxcvbn(password)
+    return result.score
+  }
+
+  const validation = (password) => {
+    if (password.length < 6) {
+      return {valid: false, message: 'Password is too short'}
+    } else {
+      let score = estimatePasswordStrength(password)
+      switch (score) {
+        case 0: case 1:
+          return {valid: false, message: 'Password strength: weak'}
+        case 2:
+          return {valid: true, message: 'Password strength: okay'}
+        case 3:
+          return {valid: true, message: 'Password strength: good'}
+        case 4:
+          return {valid: true, message: 'Password strength: great'}
+      }
+    }
+  }
+
+  let validationResult = validation(props.value)
+
+  return (
+    <ModalInput
+      label={props.label}
+      id={props.id}
+      required={props.required}
+      password={true}
+      value={props.value}
+      onChange={props.onChange}
+      validation={props.validation}
+      validationMessage={validationResult.message}
+    />
+  )
+}
+
+export default PasswordStrengthModalInput

--- a/frontend/client/src/components/PasswordStrengthModalInput.js
+++ b/frontend/client/src/components/PasswordStrengthModalInput.js
@@ -3,7 +3,7 @@ import zxcvbn from 'zxcvbn'
 import ModalInput from '../components/ModalInput'
 
 /**
- *
+ * A component combining a ModalInput with a password strength meter.
  * @param {*} props.label      the label for the component
  * @param {*} props.id         the component ID
  * @param {*} props.required

--- a/frontend/client/src/components/PasswordStrengthModalInput.js
+++ b/frontend/client/src/components/PasswordStrengthModalInput.js
@@ -3,7 +3,7 @@ import zxcvbn from 'zxcvbn'
 import ModalInput from '../components/ModalInput'
 
 /**
- * 
+ *
  * @param {*} props.label      the label for the component
  * @param {*} props.id         the component ID
  * @param {*} props.required
@@ -19,18 +19,19 @@ const PasswordStrengthModalInput = (props) => {
 
   const validation = (password) => {
     if (password.length < 6) {
-      return {valid: false, message: 'Password is too short'}
+      return { valid: false, message: 'Password is too short' }
     } else {
       let score = estimatePasswordStrength(password)
       switch (score) {
-        case 0: case 1:
-          return {valid: false, message: 'Password strength: weak'}
+        case 0:
+        case 1:
+          return { valid: false, message: 'Password strength: weak' }
         case 2:
-          return {valid: true, message: 'Password strength: okay'}
+          return { valid: true, message: 'Password strength: okay' }
         case 3:
-          return {valid: true, message: 'Password strength: good'}
+          return { valid: true, message: 'Password strength: good' }
         case 4:
-          return {valid: true, message: 'Password strength: great'}
+          return { valid: true, message: 'Password strength: great' }
       }
     }
   }

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -46,7 +46,6 @@ class ResetPasswordModalBase extends React.Component {
         case 'new-password':
           newState.newPasswordHasBeenEdited = true
           newState.password = fieldContent
-          newState.passwordIsValid = newState.password && newState.password.length >= 6
           newState.passwordsMatch = newState.password === state.confirmPassword
           break
         case 'confirm-password':
@@ -124,6 +123,9 @@ class ResetPasswordModalBase extends React.Component {
             value={this.state.password}
             onChange={this.onChange}
             validation={this.state.formHasBeenEdited}
+            notifyValidationResult={(valid) => {
+              this.setState({ passwordIsValid: valid })
+            }}
           />
 
           <ModalInput

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -6,6 +6,7 @@ import { auth } from '../store/firebase'
 import { withStore } from '../store'
 import Logging from '../util/logging'
 import firebase from 'firebase'
+import PasswordStrengthModalInput from './PasswordStrengthModalInput'
 
 class ResetPasswordModalBase extends React.Component {
   constructor(props) {
@@ -116,19 +117,13 @@ class ResetPasswordModalBase extends React.Component {
             validationMessage="Current password cannot be blank"
           />
 
-          <ModalInput
-            label="New password"
+          <PasswordStrengthModalInput
+            label="New Password"
             id="new-password"
             required={true}
-            password={true}
             value={this.state.password}
             onChange={this.onChange}
-            validation={!this.state.passwordIsValid && this.state.newPasswordHasBeenEdited}
-            validationMessage={
-              this.state.password.length > 0
-                ? 'Password must be at least 6 characters long'
-                : 'New password cannot be blank'
-            }
+            validation={this.state.formHasBeenEdited}
           />
 
           <ModalInput

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17232,15 +17232,6 @@
         "strip-indent": "^3.0.0"
       }
     },
-    "redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
-      }
-    },
     "redux-devtools-extension": {
       "version": "2.13.8",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
@@ -18783,11 +18774,6 @@
           }
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -20678,6 +20664,11 @@
           }
         }
       }
+    },
+    "zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA="
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "react-redux": "^7.2.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "redux": "^4.0.5"
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
Closes #247

Add a password strength meter to the "New password" fields in `ChangePasswordModal` and `ResetPasswordModal` using a `PasswordStrengthModalInput`, which composes `ModalInput`. This component will always display validation text, even when the password is valid.

Password strength indicator colors:
- Weak/invalid: `#f05452` (tangerine)
- Okay: `#43c4d9` (aqua)
- Good: `#388ec5`
- Great: `#2c58b1` (bluejay)

TODO:
- [x] Allow `{Reset,Change}PasswordModal` to read the validation result (true/false) of the `PasswordStrengthModalInput`
- [x] Color shouldn't be red when the password is valid