### PR TITLE
ManageMembers for Mobile

### DIFF
--- a/frontend/client/src/components/MobileMemberInfo.js
+++ b/frontend/client/src/components/MobileMemberInfo.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import RoleSelector from '../components/RoleSelector'
+import arrowRight from '../../assets/arrow-right.svg'
+import arrowDown from '../../assets/arrow-down.svg'
+
+const MobileMemberInfo = ({
+  data,
+  key,
+  memberIndex,
+  userEmail,
+  handleRoleChange,
+  handleStatusChange,
+  resetPassword,
+}) => {
+  const [showInfoState, setShowInfoState] = React.useState(false)
+  const infoClass = showInfoState ? 'show-info' : 'show-info collapse'
+
+  return (
+    <div className="mobile-member-info" key={key}>
+      <div className="show-info-btn" onClick={() => setShowInfoState(!showInfoState)}>
+        <img src={showInfoState ? arrowDown : arrowRight} />
+        <h4>{data.lastName + ', ' + data.firstName}</h4>
+      </div>
+      <div className={infoClass}>
+        <p>{data.email}</p>
+        <RoleSelector
+          memberIndex={memberIndex}
+          onChange={() => handleRoleChange(data.isAdmin, data.firstName, data.lastName, data.email)}
+        />
+        <select
+          disabled={data.email === userEmail}
+          className={!data.disabled ? 'active' : 'inactive'}
+          value={!data.disabled ? 'active' : 'deactivated'}
+          onChange={(e) => handleStatusChange(data.email, e.target.value, data.firstName, data.lastName)}
+        >
+          <option value="active">Active</option>
+          <option value="deactivated">Deactivated</option>
+        </select>
+        <a onClick={(e) => resetPassword(e, data.email)}>Reset Password</a>
+      </div>
+    </div>
+  )
+}
+
+export default MobileMemberInfo

--- a/frontend/client/src/screens/ManageTeams.js
+++ b/frontend/client/src/screens/ManageTeams.js
@@ -13,6 +13,7 @@ import PageTitle from '../components/PageTitle'
 import Logging from '../util/logging'
 import ChangeRoleModal from '../components/ChangeRoleModal'
 import ChangeStatusModal from '../components/ChangeStatusModal'
+import MobileMemberInfo from '../components/MobileMemberInfo'
 import '../../styles/screens/manage_teams.scss' // NOTE: see note in index.scss
 
 const ManageTeamsBase = observer((props) => {
@@ -107,7 +108,6 @@ const ManageTeamsBase = observer((props) => {
         <img src={addMember} alt="" />
         <span className="add-button-text">Add Member</span>
       </button>
-      <p className="mobile-msg">Use desktop to view members.</p>
       <AddMemberModal
         hidden={!showAddMemberModal}
         onClose={onAddMemberCancel}
@@ -124,6 +124,21 @@ const ManageTeamsBase = observer((props) => {
         onClose={onChangeStatusModalClose}
         userProperties={modalUserProperties}
       />
+      {props.store.data.organization.members && (
+        <div className="mobile-member-info-index">
+          {props.store.data.organization.currentPageOfMembers.map((data, idx) => (
+            <MobileMemberInfo
+              data={data}
+              key={idx}
+              memberIndex={idx + (props.store.data.organization.membersPage - 1) * PAGE_SIZE}
+              userEmail={userEmail}
+              handleRoleChange={handleRoleChange}
+              handleStatusChange={handleStatusChange}
+              resetPassword={resetPassword}
+            />
+          ))}
+        </div>
+      )}
       <table>
         <thead>
           <tr>

--- a/frontend/client/styles/components/mobile_member_info.scss
+++ b/frontend/client/styles/components/mobile_member_info.scss
@@ -1,0 +1,74 @@
+.mobile-member-info-index, .mobile-member-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.mobile-member-info-index {
+    padding: 24px 16px 8px 16px;
+    margin: 8px 0;
+    border: 1px solid $darkMediumGray;
+    border-radius: 4px;
+
+    @include media('>phone') {
+        display: none;
+    }
+}
+
+.mobile-member-info {
+    position: relative;
+    width: 280px;
+    text-align: center;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    border: 2px solid $bluejay;
+    border-radius: 4px;
+    transition: ease-in-out 0.2s;
+
+    .show-info-btn {
+        width: 100%;
+        
+        h4 {
+            padding: 0;
+            margin: 0;
+        }
+    }
+
+    .show-info {
+        display: flex;
+        flex-direction: column;
+        height: 170px;
+        overflow: hidden;
+        transition: 0.3s ease-out;
+
+        p, .custom-select, .active {
+            margin: 10px 0;
+        }
+
+        .active {
+            border-bottom: 1px solid rgb(118, 118, 118);
+        }
+
+        select {
+            padding: 4px;
+            width: 250px;
+        }
+    }
+
+    .collapse {
+        height: 0;
+    }
+
+    img {
+        position: absolute;
+        top: 12px;
+        left: 10px;
+    }
+
+    &:hover {
+        border: 2px solid #224486;
+        background: $lightGray;
+        transition: ease-in-out 0.2s;
+    }
+}

--- a/frontend/client/styles/index.scss
+++ b/frontend/client/styles/index.scss
@@ -20,3 +20,4 @@
 @import './components/modal_input.scss';
 @import './components/profile_photo.scss';
 @import './components/cancel_confirm_buttons.scss';
+@import './components/mobile_member_info.scss';

--- a/frontend/client/styles/screens/manage_teams.scss
+++ b/frontend/client/styles/screens/manage_teams.scss
@@ -104,7 +104,8 @@ table {
   line-height: 18px;
 
   @include media('<=phone') {
-    display: none;
+    align-self: center;
+    margin: 16px 0;
   }
 
   .pages-container {


### PR DESCRIPTION
Currently, we have a placeholder for the ManageMembers/ManageTeams page on mobile - this PR/draft aims to address that.  
  
Added a new `MobileMemberInfo` component, which takes the same data that would've converted into the table on desktop, and instead makes some mobile friendly components to compact the info for each team member. Here's what it looks like:  
  
![mobile_manage_members](https://user-images.githubusercontent.com/56734437/91748544-1f3a0180-eb8e-11ea-95be-7b43933d183d.gif)  
  
Current issues/concerns:  
* Can't get the `:after` on the RoleSelector to work. Pathing via url in the scss file throws up errors.  
* Amount of info shown before clicking/tapping - should we also show role?  
* Styling - any suggestions on tidying it up/making it look nicer are appreciated.  