### PR TITLE
Add "delete" option to AWS sync

### DIFF
--- a/frontend/scripts/deploy.sh
+++ b/frontend/scripts/deploy.sh
@@ -33,7 +33,7 @@ fi
 
 
 # Upload /dist (bundled web app)
-aws s3 sync $FOLDERNAME "$S3_BUCKET_URI/$FOLDERNAME" --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors
+aws s3 sync $FOLDERNAME "$S3_BUCKET_URI/$FOLDERNAME" --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors --delete
 
 
 aws cloudfront create-invalidation \


### PR DESCRIPTION
As noted in #532, with the Babel updates, the `polyfill.js` file is no longer included in the `dist/` directory (`dist/` is generated by `npm run build`). However, if you look in the S3 bucket for the portal `polyfill.js` is still there! This is because we update the `dist/` folder in S3 with the `aws s3 sync` command. By default `sync` apparently does not remove files in the bucket which were removed in source directory. So, even though `pollyfill.js` was removed from `/dist`, it remained in the bucket. So, we add the `--delete` flag to the `sync` command, which deletes any files in the bucket that are not in the source directory. Docs [here](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html). The final effect is that the source directory (`dist/`) and the S3 bucket are exactly synchronized. 

Once merged, we should again carefully test on staging to ensure no adverse effects happened. 