### PR TITLE
Timer Fix

### DIFF
--- a/frontend/client/src/components/Countdown.js
+++ b/frontend/client/src/components/Countdown.js
@@ -8,7 +8,7 @@ const Countdown = (props) => {
     timeLeft > 0 &&
       setTimeout(() => {
         setTimeLeft(timeLeft - 1)
-      }, 600)
+      }, 60000)
   }, [timeLeft])
 
   return (

--- a/frontend/client/src/components/Countdown.js
+++ b/frontend/client/src/components/Countdown.js
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from 'react'
+import Clock from '../../assets/clock.svg'
+
+const Countdown = (props) => {
+  const [timeLeft, setTimeLeft] = useState(60)
+
+  useEffect(() => {
+    timeLeft > 0 &&
+      setTimeout(() => {
+        setTimeLeft(timeLeft - 1)
+      }, 600)
+  }, [timeLeft])
+
+  return (
+    <div id="share-urgently">
+      <img src={Clock}></img>
+      <div>Share the code ASAP. &nbsp;</div>
+      {timeLeft > 0 ? (
+        <span>
+          It will expire in {timeLeft} min at {props.expirationTime}
+        </span>
+      ) : (
+        <span>Code expired after 60 minutes - generate new code.</span>
+      )}
+    </div>
+  )
+}
+
+export default Countdown

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -6,8 +6,8 @@ import { Redirect } from 'react-router-dom'
 import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import PendingOperationButton from '../components/PendingOperationButton'
-import Clock from '../../assets/clock.svg'
 import DatePicker from 'react-datepicker'
+import Countdown from '../components/Countdown'
 
 import {
   getOneHourAheadDisplayString,
@@ -18,7 +18,6 @@ import {
 } from '../util/time'
 
 const codePlaceholder = '00000000'
-let needsResetGlobal = false
 
 const CodeValidationsBase = observer((props) => {
   const [testType] = useState('confirmed')
@@ -29,7 +28,6 @@ const CodeValidationsBase = observer((props) => {
   const [code, setCode] = useState(codePlaceholder)
   const [buttonDisabled, setButtonDisabled] = useState(false)
   const [expirationTime, setExpirationTime] = useState('')
-  const [timeLeft, setTimeLeft] = useState(60)
   const [toastInfo, setToastInfo] = useState({
     success: false,
     msg: '',
@@ -44,10 +42,6 @@ const CodeValidationsBase = observer((props) => {
     updateButtonDisabled()
   })
 
-  useEffect(() => {
-    needsResetGlobal = needsReset
-  }, [needsReset])
-
   // Updates the buttonDisabled variable state based on other state variables
   const updateButtonDisabled = () => {
     if (needsReset || dateInvalid) {
@@ -55,15 +49,6 @@ const CodeValidationsBase = observer((props) => {
     } else {
       setButtonDisabled(false)
     }
-  }
-
-  const countdown = (num = 60) => {
-    setTimeout(() => {
-      if (num > 0 && needsResetGlobal) {
-        setTimeLeft(num - 1)
-        countdown(num - 1)
-      }
-    }, 600000)
   }
 
   const genNewCode = async () => {
@@ -76,7 +61,6 @@ const CodeValidationsBase = observer((props) => {
       setCode(code.data.split('').join(''))
       codeTimeStamp()
       setNeedsReset(true)
-      countdown()
       updateButtonDisabled()
       props.store.analytics.logEvent('verificationCodeGenerated', {
         organizationID: props.store.data.user.organizationID,
@@ -110,7 +94,6 @@ const CodeValidationsBase = observer((props) => {
     setCode(codePlaceholder)
     setSymptomDateYYYYMMDD('')
     setSymptomDateObject('')
-    setTimeLeft(60)
     setNeedsReset(false)
     setDateInvalid(false)
     updateButtonDisabled()
@@ -197,18 +180,7 @@ const CodeValidationsBase = observer((props) => {
 
           {needsReset && (
             <div>
-              <div id="share-urgently">
-                <img src={Clock}></img>
-                <div>Share the code ASAP. &nbsp;</div>
-                {timeLeft > 0 ? (
-                  <span>
-                    It will expire in {timeLeft} min at {expirationTime}
-                  </span>
-                ) : (
-                  <span>Code expired after 60 minutes - generate new code.</span>
-                )}
-              </div>
-
+              <Countdown expirationTime={expirationTime} />
               <PendingOperationButton operation={resetState} className="save-button">
                 Reset Code and Form
               </PendingOperationButton>

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -18,6 +18,7 @@ import {
 } from '../util/time'
 
 const codePlaceholder = '00000000'
+let needsResetGlobal = false
 
 const CodeValidationsBase = observer((props) => {
   const [testType] = useState('confirmed')
@@ -43,6 +44,10 @@ const CodeValidationsBase = observer((props) => {
     updateButtonDisabled()
   })
 
+  useEffect(() => {
+    needsResetGlobal = needsReset
+  }, [needsReset])
+
   // Updates the buttonDisabled variable state based on other state variables
   const updateButtonDisabled = () => {
     if (needsReset || dateInvalid) {
@@ -54,11 +59,11 @@ const CodeValidationsBase = observer((props) => {
 
   const countdown = (num = 60) => {
     setTimeout(() => {
-      if (num > 0 && code === codePlaceholder) {
+      if (num > 0 && needsResetGlobal) {
         setTimeLeft(num - 1)
         countdown(num - 1)
       }
-    }, 60000)
+    }, 600000)
   }
 
   const genNewCode = async () => {
@@ -71,8 +76,8 @@ const CodeValidationsBase = observer((props) => {
       setCode(code.data.split('').join(''))
       codeTimeStamp()
       setNeedsReset(true)
-      updateButtonDisabled()
       countdown()
+      updateButtonDisabled()
       props.store.analytics.logEvent('verificationCodeGenerated', {
         organizationID: props.store.data.user.organizationID,
         organizationName: props.store.data.organization.name,


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1188301658055194/1192892309652977)

Updates the countdown timer to be its own component. Previously, the timer was created by a series of recursive function calls that updated the `timeLeft` state variable. However, when the reset button was pushed, the recursion was not stopped. So, when a new code was generated on the same page, there were two recursive chains running, each updating `timeLeft` on top of each other. This is shown below with the interval between updates changed from one minute to one second.

![out](https://user-images.githubusercontent.com/20446774/92881594-fa326380-f3c3-11ea-8019-9e5269464c80.gif)

Now that the countdown timer is its own component, on reset the component is unmounted so the timer disappears. Also lets the time updates be triggered by the `useEffect` hook, which avoids the recursion. 

Now, with one second updates we get:
![out2](https://user-images.githubusercontent.com/20446774/92883440-b0e31380-f3c5-11ea-880e-3433263ae5a6.gif)


